### PR TITLE
fix(unit): disable test parallelization to fix CI race

### DIFF
--- a/backend/SistemaServicios.Tests/TestConfiguration.cs
+++ b/backend/SistemaServicios.Tests/TestConfiguration.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+// Las pruebas manipulan variables de entorno del proceso (estado global).
+// BackupServiceTests pone env vars a null para probar validaciones, mientras
+// que CustomWebApplicationFactory las establece en su constructor.
+// Si ambas clases corren en paralelo, hay una condición de carrera que provoca
+// fallos intermitentes en CI. Deshabilitar el paralelismo entre colecciones
+// elimina la carrera sin modificar la lógica de producción ni de pruebas.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
# 🚀 Solicitud de Pull Request

Gracias por tu contribución. Por favor, completa la siguiente información para ayudar al equipo a revisar y aprobar este PR de manera eficiente.

---

## 📌 Resumen del Cambio

Se corrige una condición de carrera en la suite de pruebas del backend que provocaba fallos intermitentes en los workflows de GitHub Actions (CI).

Por defecto, xUnit ejecuta las clases de prueba **en paralelo**. En CI (runner Ubuntu multi-core), `BackupServiceTests` ponía variables de entorno a `null` (p. ej. `DB_HOST`, `DB_USER`) para verificar validaciones, mientras que otras clases de integración (`CustomWebApplicationFactory`) leían o escribían esas mismas variables al mismo tiempo. Esto causaba que, según el orden de ejecución:

- `SwaggerTests.Swagger_DocumentoOpenApi_ContentTypeEsJson` fallaba con `InvalidOperationException: DB_HOST no definido en el archivo .env`
- `BackupServiceTests.GenerateBackupAsync_SinDbUser_LanzaInvalidOperationException` fallaba con `pg_dump falló: Connection refused` (el valor nulo había sido restaurado por otra clase antes de que el test lo leyera)

La corrección deshabilita el paralelismo entre colecciones con `[assembly: CollectionBehavior(DisableTestParallelization = true)]` en un nuevo archivo `TestConfiguration.cs`. Con ejecución secuencial, `BackupServiceTests.Dispose()` restaura las variables antes de que comience la siguiente clase, eliminando la carrera por completo. Los 80 tests siguen pasando en ≈ 8 segundos.

---

## 🔍 Tipo de Cambio realizado

Marca con una `x` lo que aplica:

- [x] 🐞 Corrección de error (`fix`)
- [ ] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [x] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

**Nuevo:**
- `backend/SistemaServicios.Tests/TestConfiguration.cs` — atributo `[assembly: CollectionBehavior(DisableTestParallelization = true)]` que desactiva el paralelismo entre clases de prueba

---

## 🧪 ¿Cómo Probarlo?

```bash
cd backend
dotnet test SistemaServicios.Tests --configuration Release
# Resultado esperado: 80 pruebas — 80 aprobadas, 0 fallidas
```

Para verificar que la condición de carrera ya no ocurre, ejecutar varias veces seguidas:

```bash
for i in {1..5}; do dotnet test SistemaServicios.Tests --configuration Release --no-build; done
```

Todos los runs deben reportar `Passed: 80`.

---

## ✅ Checklist

Asegúrate de completar lo siguiente antes de enviar:

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [x] Se han actualizado o agregado pruebas
- [x] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

---

## 📎 Notas Adicionales

- **Causa raíz**: variables de entorno del proceso son estado global. `BackupServiceTests` las pone a `null` para probar validaciones; las factories de integración las leen durante la construcción del host. En un runner multi-core ambas operaciones ocurren simultáneamente.
- **Por qué pasa localmente**: en equipos de desarrollo con menos núcleos o con el runner secuencial de Visual Studio, el paralelismo es menor y la ventana de la carrera prácticamente no existe.
- **Impacto en rendimiento**: nulo. La suite completa corre en ≈ 8 s tanto en paralelo como en secuencial.
- **Commit incluido**:

  | Hash | Mensaje |
  |------|---------|
  | `b9de711` | `fix(unit): disable test parallelization to fix CI race` |

- Issue relacionado: continuación del trabajo de CI iniciado en el PR #78 (`test/testing-br → main`).

---

Gracias 🙌
