### PR TITLE
[feat]: 48-Headers de seguridad

### DIFF
--- a/backend/SistemaServicios.API/Program.cs
+++ b/backend/SistemaServicios.API/Program.cs
@@ -24,6 +24,15 @@ if (app.Environment.IsDevelopment())
     });
 }
 
+app.Use(async (context, next) =>
+{
+    context.Response.Headers.Append("Content-Security-Policy", "default-src 'self'");
+    context.Response.Headers.Append("X-Frame-Options", "DENY");
+    context.Response.Headers.Append("X-Content-Type-Options", "nosniff");
+    context.Response.Headers.Append("Referrer-Policy", "strict-origin-when-cross-origin");
+    await next();
+});
+
 app.UseHttpsRedirection();
 app.UseCors("FrontendPolicy");
 app.UseAuthentication();


### PR DESCRIPTION
# 🚀 Solicitud de Pull Request

Gracias por tu contribución. Por favor, completa la siguiente información para ayudar al equipo a revisar y aprobar este PR de manera eficiente.

---

## 📌 Resumen del Cambio

Se agrega middleware en `Program.cs` que inyecta los headers de seguridad HTTP en todas las respuestas del backend. Esto protege la aplicación contra ataques XSS, clickjacking y MIME sniffing, mejorando el score de Mozilla Observatory de **F** a al menos **C**.

---

## 🔍 Tipo de Cambio realizado

Marca con una `x` lo que aplica:

- [ ] 🐞 Corrección de error (`fix`)
- [x] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [ ] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

- `backend/SistemaServicios.API/Program.cs`

---

## 🧪 ¿Cómo Probarlo?

1. Levantar el backend:
   ```bash
   dotnet run --project backend/SistemaServicios.API
   ```
2. Realizar cualquier request a un endpoint (ej. `/api/Auth/login`) con DevTools abierto.
3. En **DevTools → Network → Response Headers**, verificar que aparecen:
   - `Content-Security-Policy: default-src 'self'`
   - `X-Frame-Options: DENY`
   - `X-Content-Type-Options: nosniff`
   - `Referrer-Policy: strict-origin-when-cross-origin`
4. (Opcional) Exponer con ngrok y analizar con [Mozilla Observatory](https://developer.mozilla.org/en-US/observatory/analyze) — debe obtener al menos grado **C**.

---

## ✅ Checklist

Asegúrate de completar lo siguiente antes de enviar:

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [ ] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Resuelve el issue #48.

El middleware `app.Use(...)` se ubica **antes** de `UseHttpsRedirection()` y `MapControllers()`, garantizando que toda respuesta incluya los headers de seguridad.

> ⚠️ La política `Content-Security-Policy: default-src 'self'` puede bloquear recursos inline de Swagger UI. Verificar en desarrollo que Swagger sigue operando correctamente tras el merge.

---

Gracias 🙌
