### PR TITLE
Feat/backend servicios profesionista

### DIFF
--- a/backend/SistemaServicios.API/Controllers/ServiceRequestsController.cs
+++ b/backend/SistemaServicios.API/Controllers/ServiceRequestsController.cs
@@ -21,7 +21,7 @@ public class ServiceRequestsController : ControllerBase
     }
 
     /// <summary>Crear una nueva solicitud de servicio. El ClientId se extrae del JWT.</summary>
-    [Authorize(Roles = "Client")]
+    [Authorize(Roles = "Client,Professional")]
     [HttpPost]
     public async Task<ActionResult<ServiceRequestDto>> CreateRequest(
         [FromBody] CreateServiceRequestDto dto
@@ -87,8 +87,8 @@ public class ServiceRequestsController : ControllerBase
         }
     }
 
-    /// <summary>Solicitudes realizadas por el cliente autenticado.</summary>
-    [Authorize(Roles = "Client")]
+    /// <summary>Solicitudes realizadas por el usuario autenticado (Cliente o Profesionista).</summary>
+    [Authorize(Roles = "Client,Professional")]
     [HttpGet("my")]
     public async Task<ActionResult> GetMyRequests(
         [FromQuery] int page = 1,

--- a/backend/SistemaServicios.API/Services/ServiceRequestService.cs
+++ b/backend/SistemaServicios.API/Services/ServiceRequestService.cs
@@ -8,17 +8,14 @@ public class ServiceRequestService : IServiceRequestService
 {
     private readonly IServiceRequestRepository _repository;
     private readonly IServiceRepository _serviceRepository;
-    private readonly IUserRepository _userRepository;
 
     public ServiceRequestService(
         IServiceRequestRepository repository,
-        IServiceRepository serviceRepository,
-        IUserRepository userRepository
+        IServiceRepository serviceRepository
     )
     {
         _repository = repository;
         _serviceRepository = serviceRepository;
-        _userRepository = userRepository;
     }
 
     public async Task<ServiceRequestDto> CreateRequestAsync(
@@ -32,12 +29,6 @@ public class ServiceRequestService : IServiceRequestService
             throw new KeyNotFoundException(
                 $"El servicio con ID {dto.ServiceId} no existe o no está disponible."
             );
-        }
-
-        var client = await _userRepository.GetByIdAsync(clientId);
-        if (client is null)
-        {
-            throw new KeyNotFoundException($"El cliente con ID {clientId} no existe.");
         }
 
         var request = new Request


### PR DESCRIPTION
This pull request updates the access control for service request endpoints in the `ServiceRequestsController` to allow both clients and professionals to create and view their own service requests. The changes broaden the roles permitted to use these endpoints, improving flexibility in the API.

Authorization updates:

* The `[Authorize]` attribute for the `CreateRequest` method now allows both `Client` and `Professional` roles to create service requests, instead of only `Client`. (`backend/SistemaServicios.API/Controllers/ServiceRequestsController.cs`, [backend/SistemaServicios.API/Controllers/ServiceRequestsController.csL24-R24](diffhunk://#diff-6137664ade6305fd4fb765934d0630b55a883cd37697f3714a23c49946f278d6L24-R24))
* The `[Authorize]` attribute and summary for the `GetMyRequests` method have been updated so that both `Client` and `Professional` users can view their own requests, reflecting the expanded access. (`backend/SistemaServicios.API/Controllers/ServiceRequestsController.cs`, [backend/SistemaServicios.API/Controllers/ServiceRequestsController.csL90-R91](diffhunk://#diff-6137664ade6305fd4fb765934d0630b55a883cd37697f3714a23c49946f278d6L90-R91))Branch: feat/backend-servicios-profesionista
This pull request updates the authorization logic for service requests and simplifies the `ServiceRequestService` by removing unnecessary user validation. The main changes expand access to both clients and professionals, and streamline the service layer by eliminating redundant repository usage.

**Authorization updates:**

* The `[Authorize]` attribute in `ServiceRequestsController` methods now allows both "Client" and "Professional" roles to create and view their own service requests, instead of restricting these actions to clients only. [[1]](diffhunk://#diff-6137664ade6305fd4fb765934d0630b55a883cd37697f3714a23c49946f278d6L24-R24) [[2]](diffhunk://#diff-6137664ade6305fd4fb765934d0630b55a883cd37697f3714a23c49946f278d6L90-R91)

**Service layer simplification:**

* Removed the dependency on `IUserRepository` from `ServiceRequestService`, and eliminated the client existence check when creating a service request, relying on the provided `clientId` as valid. [[1]](diffhunk://#diff-02e08dc9954da25796bf50cbbe66c3b59170d949a89cf7ac6a57bacbffd514e0L11-L21) [[2]](diffhunk://#diff-02e08dc9954da25796bf50cbbe66c3b59170d949a89cf7ac6a57bacbffd514e0L37-L42)