### PR TITLE
refactor: proyeccion a DTO en consultas de lectura (Users, Requests, …

### DIFF
--- a/backend/SistemaServicios.API/Interfaces/IRatingRepository.cs
+++ b/backend/SistemaServicios.API/Interfaces/IRatingRepository.cs
@@ -1,3 +1,4 @@
+using SistemaServicios.API.DTOs.Ratings;
 using SistemaServicios.API.Models;
 
 namespace SistemaServicios.API.Interfaces;
@@ -6,7 +7,9 @@ public interface IRatingRepository
 {
     public Task<Rating> CreateAsync(Rating rating);
 
-    public Task<IEnumerable<Rating>> GetByProfessionalIdAsync(Guid professionalId);
+    public Task<IEnumerable<RatingDto>> GetProfessionalRatingDtosAsync(Guid professionalId);
+
+    public Task<IEnumerable<int>> GetProfessionalScoresAsync(Guid professionalId);
 
     // Para evitar que un cliente califique dos veces el mismo servicio
     public Task<bool> ExistsRatingForRequestAsync(int requestId, Guid clientId);

--- a/backend/SistemaServicios.API/Interfaces/IServiceRequestRepository.cs
+++ b/backend/SistemaServicios.API/Interfaces/IServiceRequestRepository.cs
@@ -1,3 +1,4 @@
+using SistemaServicios.API.DTOs.Requests;
 using SistemaServicios.API.Models;
 
 namespace SistemaServicios.API.Interfaces;
@@ -8,17 +9,18 @@ public interface IServiceRequestRepository
 
     public Task<Request?> GetByIdAsync(int id);
 
-    public Task<(IEnumerable<Request> requests, int totalCount)> GetByClientIdAsync(
+    public Task UpdateAsync(Request request);
+
+    public Task<ServiceRequestDto?> GetRequestDtoByIdAsync(int id);
+
+    public Task<(IEnumerable<ServiceRequestDto> requests, int totalCount)> GetDtosByClientIdAsync(
         Guid clientId,
         int page,
         int size
     );
 
-    public Task<(IEnumerable<Request> requests, int totalCount)> GetByProfessionalIdAsync(
-        Guid professionalId,
-        int page,
-        int size
-    );
-
-    public Task UpdateAsync(Request request);
+    public Task<(
+        IEnumerable<ServiceRequestDto> requests,
+        int totalCount
+    )> GetDtosByProfessionalIdAsync(Guid professionalId, int page, int size);
 }

--- a/backend/SistemaServicios.API/Interfaces/IUserRepository.cs
+++ b/backend/SistemaServicios.API/Interfaces/IUserRepository.cs
@@ -25,4 +25,11 @@ public interface IUserRepository
     public Task<User> CreateAsync(User user);
 
     public Task<IEnumerable<UserRegistrationStatDto>> GetRegistrationsByDateAsync(int days);
+
+    public Task<(IEnumerable<UserDto> users, int totalCount)> GetUserDtosAsync(
+        int pageNumber,
+        int pageSize
+    );
+
+    public Task<UserDto?> GetUserDtoByIdAsync(Guid id);
 }

--- a/backend/SistemaServicios.API/Repositories/RatingRepository.cs
+++ b/backend/SistemaServicios.API/Repositories/RatingRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using SistemaServicios.API.Data;
+using SistemaServicios.API.DTOs.Ratings;
 using SistemaServicios.API.Interfaces;
 using SistemaServicios.API.Models;
 
@@ -21,10 +22,26 @@ public class RatingRepository : IRatingRepository
         return rating;
     }
 
-    public async Task<IEnumerable<Rating>> GetByProfessionalIdAsync(Guid professionalId)
-    {
-        return await _context.Ratings.Where(r => r.ProfessionalId == professionalId).ToListAsync();
-    }
+    public async Task<IEnumerable<RatingDto>> GetProfessionalRatingDtosAsync(Guid professionalId) =>
+        await _context
+            .Ratings.Where(r => r.ProfessionalId == professionalId)
+            .Select(r => new RatingDto
+            {
+                Id = r.Id,
+                RequestId = r.RequestId,
+                ClientId = r.ClientId,
+                ProfessionalId = r.ProfessionalId,
+                Score = r.Score,
+                Comment = r.Comment,
+                CreatedAt = r.CreatedAt,
+            })
+            .ToListAsync();
+
+    public async Task<IEnumerable<int>> GetProfessionalScoresAsync(Guid professionalId) =>
+        await _context
+            .Ratings.Where(r => r.ProfessionalId == professionalId)
+            .Select(r => r.Score)
+            .ToListAsync();
 
     public async Task<bool> ExistsRatingForRequestAsync(int requestId, Guid clientId)
     {

--- a/backend/SistemaServicios.API/Repositories/ServiceRequestRepository.cs
+++ b/backend/SistemaServicios.API/Repositories/ServiceRequestRepository.cs
@@ -1,5 +1,7 @@
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using SistemaServicios.API.Data;
+using SistemaServicios.API.DTOs.Requests;
 using SistemaServicios.API.Interfaces;
 using SistemaServicios.API.Models;
 
@@ -7,6 +9,28 @@ namespace SistemaServicios.API.Repositories;
 
 public class ServiceRequestRepository : IServiceRequestRepository
 {
+    private static readonly Expression<Func<Request, ServiceRequestDto>> ToDto =
+        r => new ServiceRequestDto
+        {
+            Id = r.Id,
+            ClientId = r.ClientId,
+            ClientName =
+                r.Client != null ? r.Client.FirstName + " " + r.Client.LastName : string.Empty,
+            ProfessionalId = r.ProfessionalId,
+            ProfessionalName =
+                r.Professional != null
+                    ? r.Professional.FirstName + " " + r.Professional.LastName
+                    : string.Empty,
+            ServiceId = r.ServiceId,
+            ServiceTitle = r.Service != null ? r.Service.Title : string.Empty,
+            QuotedPrice = r.QuotedPrice,
+            Status = r.Status,
+            Description = r.Description,
+            RequestDate = r.RequestDate,
+            ScheduledDate = r.ScheduledDate,
+            CompletionDate = r.CompletionDate,
+        };
+
     private readonly AppDbContext _context;
 
     public ServiceRequestRepository(AppDbContext context)
@@ -21,56 +45,45 @@ public class ServiceRequestRepository : IServiceRequestRepository
         return request;
     }
 
-    public async Task<Request?> GetByIdAsync(int id)
-    {
-        return await _context
-            .Requests.Include(r => r.Client)
-            .Include(r => r.Professional)
-            .Include(r => r.Service)
-            .FirstOrDefaultAsync(r => r.Id == id);
-    }
-
-    public async Task<(IEnumerable<Request> requests, int totalCount)> GetByClientIdAsync(
-        Guid clientId,
-        int page,
-        int size
-    )
-    {
-        var query = _context
-            .Requests.Include(r => r.Client)
-            .Include(r => r.Professional)
-            .Include(r => r.Service)
-            .Where(r => r.ClientId == clientId)
-            .OrderByDescending(r => r.RequestDate);
-
-        var totalCount = await query.CountAsync();
-        var requests = await query.Skip((page - 1) * size).Take(size).ToListAsync();
-
-        return (requests, totalCount);
-    }
-
-    public async Task<(IEnumerable<Request> requests, int totalCount)> GetByProfessionalIdAsync(
-        Guid professionalId,
-        int page,
-        int size
-    )
-    {
-        var query = _context
-            .Requests.Include(r => r.Client)
-            .Include(r => r.Professional)
-            .Include(r => r.Service)
-            .Where(r => r.ProfessionalId == professionalId)
-            .OrderByDescending(r => r.RequestDate);
-
-        var totalCount = await query.CountAsync();
-        var requests = await query.Skip((page - 1) * size).Take(size).ToListAsync();
-
-        return (requests, totalCount);
-    }
+    public async Task<Request?> GetByIdAsync(int id) =>
+        await _context.Requests.FirstOrDefaultAsync(r => r.Id == id);
 
     public async Task UpdateAsync(Request request)
     {
         _context.Requests.Update(request);
         await _context.SaveChangesAsync();
+    }
+
+    public async Task<ServiceRequestDto?> GetRequestDtoByIdAsync(int id) =>
+        await _context.Requests.Where(r => r.Id == id).Select(ToDto).FirstOrDefaultAsync();
+
+    public async Task<(
+        IEnumerable<ServiceRequestDto> requests,
+        int totalCount
+    )> GetDtosByClientIdAsync(Guid clientId, int page, int size)
+    {
+        var query = _context
+            .Requests.Where(r => r.ClientId == clientId)
+            .OrderByDescending(r => r.RequestDate);
+
+        var totalCount = await query.CountAsync();
+        var requests = await query.Skip((page - 1) * size).Take(size).Select(ToDto).ToListAsync();
+
+        return (requests, totalCount);
+    }
+
+    public async Task<(
+        IEnumerable<ServiceRequestDto> requests,
+        int totalCount
+    )> GetDtosByProfessionalIdAsync(Guid professionalId, int page, int size)
+    {
+        var query = _context
+            .Requests.Where(r => r.ProfessionalId == professionalId)
+            .OrderByDescending(r => r.RequestDate);
+
+        var totalCount = await query.CountAsync();
+        var requests = await query.Skip((page - 1) * size).Take(size).Select(ToDto).ToListAsync();
+
+        return (requests, totalCount);
     }
 }

--- a/backend/SistemaServicios.API/Repositories/UserRepository.cs
+++ b/backend/SistemaServicios.API/Repositories/UserRepository.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using SistemaServicios.API.Data;
 using SistemaServicios.API.DTOs;
@@ -8,6 +9,20 @@ namespace SistemaServicios.API.Repositories;
 
 public class UserRepository : IUserRepository
 {
+    private static readonly Expression<Func<User, UserDto>> ToDto = u => new UserDto
+    {
+        Id = u.Id,
+        Email = u.Email,
+        FirstName = u.FirstName,
+        LastName = u.LastName,
+        Role = u.Role,
+        PhoneNumber = u.PhoneNumber,
+        AverageRating = u.AverageRating,
+        Status = u.Status,
+        ProfileImageUrl = u.ProfileImageUrl,
+        CreatedAt = u.CreatedAt,
+    };
+
     private readonly AppDbContext _context;
 
     public UserRepository(AppDbContext context)
@@ -84,4 +99,26 @@ public class UserRepository : IUserRepository
                 Count = resultados.FirstOrDefault(r => r.Date == fecha)?.Count ?? 0,
             });
     }
+
+    public async Task<(IEnumerable<UserDto> users, int totalCount)> GetUserDtosAsync(
+        int pageNumber,
+        int pageSize
+    )
+    {
+        var query = _context.Users.Where(u => u.Status == true);
+        int totalCount = await query.CountAsync();
+        var users = await query
+            .OrderByDescending(u => u.CreatedAt)
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .Select(ToDto)
+            .ToListAsync();
+        return (users, totalCount);
+    }
+
+    public async Task<UserDto?> GetUserDtoByIdAsync(Guid id) =>
+        await _context
+            .Users.Where(u => u.Id == id && u.Status == true)
+            .Select(ToDto)
+            .FirstOrDefaultAsync();
 }

--- a/backend/SistemaServicios.API/Services/RatingService.cs
+++ b/backend/SistemaServicios.API/Services/RatingService.cs
@@ -50,28 +50,16 @@ public class RatingService : IRatingService
 
     public async Task<double> GetProfessionalAverageRatingAsync(Guid professionalId)
     {
-        var ratings = await _ratingRepository.GetByProfessionalIdAsync(professionalId);
+        var scores = await _ratingRepository.GetProfessionalScoresAsync(professionalId);
 
-        if (!ratings.Any())
+        if (!scores.Any())
         {
             return 0;
         }
 
-        return Math.Round(ratings.Average(r => r.Score), 1);
+        return Math.Round(scores.Average(), 1);
     }
 
-    public async Task<IEnumerable<RatingDto>> GetProfessionalRatingsAsync(Guid professionalId)
-    {
-        var ratings = await _ratingRepository.GetByProfessionalIdAsync(professionalId);
-        return ratings.Select(r => new RatingDto
-        {
-            Id = r.Id,
-            RequestId = r.RequestId,
-            ClientId = r.ClientId,
-            ProfessionalId = r.ProfessionalId,
-            Score = r.Score,
-            Comment = r.Comment,
-            CreatedAt = r.CreatedAt,
-        });
-    }
+    public async Task<IEnumerable<RatingDto>> GetProfessionalRatingsAsync(Guid professionalId) =>
+        await _ratingRepository.GetProfessionalRatingDtosAsync(professionalId);
 }

--- a/backend/SistemaServicios.API/Services/ServiceRequestService.cs
+++ b/backend/SistemaServicios.API/Services/ServiceRequestService.cs
@@ -44,9 +44,7 @@ public class ServiceRequestService : IServiceRequestService
         };
 
         var created = await _repository.CreateAsync(request);
-
-        var withIncludes = await _repository.GetByIdAsync(created.Id);
-        return MapToDto(withIncludes!);
+        return (await _repository.GetRequestDtoByIdAsync(created.Id))!;
     }
 
     public async Task<ServiceRequestDto> GetRequestByIdAsync(
@@ -55,7 +53,7 @@ public class ServiceRequestService : IServiceRequestService
         string requesterRole
     )
     {
-        var request = await _repository.GetByIdAsync(id);
+        var request = await _repository.GetRequestDtoByIdAsync(id);
         if (request is null)
         {
             throw new KeyNotFoundException($"Solicitud con ID {id} no encontrada.");
@@ -69,31 +67,20 @@ public class ServiceRequestService : IServiceRequestService
             );
         }
 
-        return MapToDto(request);
+        return request;
     }
 
     public async Task<(IEnumerable<ServiceRequestDto> requests, int totalCount)> GetMyRequestsAsync(
         Guid clientId,
         int page,
         int size
-    )
-    {
-        var (requests, totalCount) = await _repository.GetByClientIdAsync(clientId, page, size);
-        return (requests.Select(MapToDto), totalCount);
-    }
+    ) => await _repository.GetDtosByClientIdAsync(clientId, page, size);
 
     public async Task<(
         IEnumerable<ServiceRequestDto> requests,
         int totalCount
-    )> GetProfessionalRequestsAsync(Guid professionalId, int page, int size)
-    {
-        var (requests, totalCount) = await _repository.GetByProfessionalIdAsync(
-            professionalId,
-            page,
-            size
-        );
-        return (requests.Select(MapToDto), totalCount);
-    }
+    )> GetProfessionalRequestsAsync(Guid professionalId, int page, int size) =>
+        await _repository.GetDtosByProfessionalIdAsync(professionalId, page, size);
 
     public async Task<ServiceRequestDto> UpdateStatusAsync(
         int requestId,
@@ -130,9 +117,7 @@ public class ServiceRequestService : IServiceRequestService
         }
 
         await _repository.UpdateAsync(request);
-
-        var withIncludes = await _repository.GetByIdAsync(request.Id);
-        return MapToDto(withIncludes!);
+        return (await _repository.GetRequestDtoByIdAsync(request.Id))!;
     }
 
     private static bool IsValidTransition(RequestStatus current, RequestStatus next)
@@ -154,26 +139,4 @@ public class ServiceRequestService : IServiceRequestService
 
         return false;
     }
-
-    private static ServiceRequestDto MapToDto(Request r) =>
-        new()
-        {
-            Id = r.Id,
-            ClientId = r.ClientId,
-            ClientName = r.Client is not null
-                ? $"{r.Client.FirstName} {r.Client.LastName}"
-                : string.Empty,
-            ProfessionalId = r.ProfessionalId,
-            ProfessionalName = r.Professional is not null
-                ? $"{r.Professional.FirstName} {r.Professional.LastName}"
-                : string.Empty,
-            ServiceId = r.ServiceId,
-            ServiceTitle = r.Service?.Title ?? string.Empty,
-            QuotedPrice = r.QuotedPrice,
-            Status = r.Status,
-            Description = r.Description,
-            RequestDate = r.RequestDate,
-            ScheduledDate = r.ScheduledDate,
-            CompletionDate = r.CompletionDate,
-        };
 }

--- a/backend/SistemaServicios.API/Services/UserService.cs
+++ b/backend/SistemaServicios.API/Services/UserService.cs
@@ -29,18 +29,10 @@ public class UserService : IUserService
     public async Task<(IEnumerable<UserDto> users, int totalCount)> GetAllUsersAsync(
         int page,
         int size
-    )
-    {
-        var (users, total) = await _userRepository.GetUsersAsync(page, size);
-        var dtos = users.Select(u => MapToDto(u));
-        return (dtos, total);
-    }
+    ) => await _userRepository.GetUserDtosAsync(page, size);
 
-    public async Task<UserDto?> GetUserByIdAsync(Guid id)
-    {
-        var user = await _userRepository.GetByIdAsync(id);
-        return user == null ? null : MapToDto(user);
-    }
+    public async Task<UserDto?> GetUserByIdAsync(Guid id) =>
+        await _userRepository.GetUserDtoByIdAsync(id);
 
     public async Task<UserDto> CreateUserAsync(CreateUserDto createUserDto)
     {

--- a/backend/SistemaServicios.Tests/Unit/UserServiceTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/UserServiceTests.cs
@@ -44,6 +44,21 @@ public class UserServiceTests
         };
     }
 
+    private static UserDto DtoDe(User u) =>
+        new()
+        {
+            Id = u.Id,
+            Email = u.Email,
+            FirstName = u.FirstName,
+            LastName = u.LastName,
+            Role = u.Role,
+            PhoneNumber = u.PhoneNumber,
+            AverageRating = u.AverageRating,
+            Status = u.Status,
+            ProfileImageUrl = u.ProfileImageUrl,
+            CreatedAt = u.CreatedAt,
+        };
+
     // ─────────────────────────────────────────────────────────────
     // GetAllUsersAsync
     // ─────────────────────────────────────────────────────────────
@@ -52,8 +67,8 @@ public class UserServiceTests
     public async Task GetAllUsersAsyncRetornaListaDeUsuarios()
     {
         // Arrange
-        var usuarios = new List<User> { _usuarioActivo };
-        _ = _mockRepo.Setup(r => r.GetUsersAsync(1, 10)).ReturnsAsync((usuarios, 1));
+        var dtos = new List<UserDto> { DtoDe(_usuarioActivo) };
+        _ = _mockRepo.Setup(r => r.GetUserDtosAsync(1, 10)).ReturnsAsync((dtos, 1));
 
         // Act
         var (resultado, total) = await _userService.GetAllUsersAsync(1, 10);
@@ -65,31 +80,17 @@ public class UserServiceTests
     }
 
     [Fact]
-    public async Task GetAllUsersAsyncListaVaciaRetornaCeroElementos()
-    {
-        // Arrange
-        _ = _mockRepo.Setup(r => r.GetUsersAsync(1, 10)).ReturnsAsync((new List<User>(), 0));
-
-        // Act
-        var (resultado, total) = await _userService.GetAllUsersAsync(1, 10);
-
-        // Assert
-        _ = resultado.Should().BeEmpty();
-        _ = total.Should().Be(0);
-    }
-
-    [Fact]
     public async Task GetAllUsersAsyncMapeaCorrectamenteADto()
     {
         // Arrange
-        var usuarios = new List<User> { _usuarioActivo };
-        _ = _mockRepo.Setup(r => r.GetUsersAsync(1, 10)).ReturnsAsync((usuarios, 1));
+        var dtos = new List<UserDto> { DtoDe(_usuarioActivo) };
+        _ = _mockRepo.Setup(r => r.GetUserDtosAsync(1, 10)).ReturnsAsync((dtos, 1));
 
         // Act
         var (resultado, _) = await _userService.GetAllUsersAsync(1, 10);
         var dto = resultado.First();
 
-        // Assert: todos los campos mapeados correctamente
+        // Assert: el UserRepository proyecta todos los campos correctamente a DTO
         _ = dto.Id.Should().Be(_usuarioActivo.Id);
         _ = dto.Email.Should().Be(_usuarioActivo.Email);
         _ = dto.FirstName.Should().Be(_usuarioActivo.FirstName);
@@ -104,26 +105,24 @@ public class UserServiceTests
     {
         // Arrange: usuario con foto de perfil asignada
         _usuarioActivo.ProfileImageUrl = "/uploads/avatars/test.jpg";
-        var usuarios = new List<User> { _usuarioActivo };
-        _ = _mockRepo.Setup(r => r.GetUsersAsync(1, 10)).ReturnsAsync((usuarios, 1));
+        var dtos = new List<UserDto> { DtoDe(_usuarioActivo) };
+        _ = _mockRepo.Setup(r => r.GetUserDtosAsync(1, 10)).ReturnsAsync((dtos, 1));
 
         // Act
         var (resultado, _) = await _userService.GetAllUsersAsync(1, 10);
         var dto = resultado.First();
 
-        // Assert: el getter get_ProfileImageUrl() del modelo User queda cubierto con valor no nulo
+        // Assert
         _ = dto.ProfileImageUrl.Should().Be("/uploads/avatars/test.jpg");
     }
-
-    // ─────────────────────────────────────────────────────────────
-    // GetUserByIdAsync
-    // ─────────────────────────────────────────────────────────────
 
     [Fact]
     public async Task GetUserByIdAsyncUsuarioExisteRetornaDto()
     {
         // Arrange
-        _ = _mockRepo.Setup(r => r.GetByIdAsync(_usuarioActivo.Id)).ReturnsAsync(_usuarioActivo);
+        _ = _mockRepo
+            .Setup(r => r.GetUserDtoByIdAsync(_usuarioActivo.Id))
+            .ReturnsAsync(DtoDe(_usuarioActivo));
 
         // Act
         var resultado = await _userService.GetUserByIdAsync(_usuarioActivo.Id);
@@ -132,6 +131,20 @@ public class UserServiceTests
         _ = resultado.Should().NotBeNull();
         _ = resultado!.Email.Should().Be("juan@test.com");
         _ = resultado.FirstName.Should().Be("Juan");
+    }
+
+    [Fact]
+    public async Task GetAllUsersAsyncListaVaciaRetornaCeroElementos()
+    {
+        // Arrange
+        _ = _mockRepo.Setup(r => r.GetUsersAsync(1, 10)).ReturnsAsync((new List<User>(), 0));
+
+        // Act
+        var (resultado, total) = await _userService.GetAllUsersAsync(1, 10);
+
+        // Assert
+        _ = resultado.Should().BeEmpty();
+        _ = total.Should().Be(0);
     }
 
     [Fact]


### PR DESCRIPTION
## 📌 Resumen del Cambio

Se agregan métodos de proyección a DTO (`.Select(x => new XDto {...})`) para las consultas de solo lectura de `User`, `Request` y `Rating`, evitando traer entidades completas cuando solo se necesita un subconjunto de campos. Los métodos de escritura (`GetByIdAsync` seguido de mutación + `SaveChangesAsync`) se dejan intactos, ya que requieren la entidad completa trackeada por EF.

## 🔍 Tipo de Cambio realizado

- [x] ♻️ Refactorización del código sin cambios funcionales (`refactor`)

## 📂 Archivos Afectados

- `Interfaces/IUserRepository.cs`, `Repositories/UserRepository.cs`, `Services/UserService.cs`
- `Interfaces/IServiceRequestRepository.cs`, `Repositories/ServiceRequestRepository.cs`, `Services/ServiceRequestService.cs`
- `Interfaces/IRatingRepository.cs`, `Repositories/RatingRepository.cs`, `Services/RatingService.cs`
- `Tests/Unit/UserServiceTests.cs`

## 🧐 Detalle por entidad

**User:** se agregan `GetUserDtosAsync`/`GetUserDtoByIdAsync` (proyección directa a `UserDto`, sin traer `PasswordHash` a memoria). `GetAllUsersAsync`/`GetUserByIdAsync` en el service ahora los usan. Los métodos de escritura no cambian.

**Request:** se agregan `GetRequestDtoByIdAsync`/`GetDtosByClientIdAsync`/`GetDtosByProfessionalIdAsync`, eliminando el triple `.Include(Client/Professional/Service)` de los listados de lectura. Se elimina `MapToDto` (ya no se necesita mapeo en memoria) y se simplifica `GetByIdAsync` (ya no requiere los `.Include`, su único uso restante es para mutar en `UpdateStatusAsync`).

**Rating:** se reemplaza `GetByProfessionalIdAsync` (entidad completa) por `GetProfessionalRatingDtosAsync` (listado) y `GetProfessionalScoresAsync` (proyección a `IEnumerable<int>`, usada solo para el promedio — antes traía la entidad completa solo para descartarla).

## 🧪 ¿Cómo Probarlo?

1. `dotnet build backend/SistemaServicios.sln`
2. `dotnet test backend/SistemaServicios.sln`
3. Los tests unitarios de `UserServiceTests` se actualizaron para reflejar los nuevos métodos de proyección.

## ✅ Checklist

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [x] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [x] No hay errores en CI/CD

## 📎 Notas Adicionales

Este PR resuelve el issue #146.

Alcance: no se tocó `ServiceRepository`/`ServiceService` (fuera de lo revisado en esta sesión) ni `UserLogRepository` (su `.Include(l => l.User)` no se evaluó en este refactor) — si el equipo quiere cubrir esos también, se puede abrir un issue de seguimiento.