### PR TITLE
feat(frontend): pantalla de respaldos en el panel de administración

### DIFF
--- a/frontend/app/usuarios/respaldos/page.tsx
+++ b/frontend/app/usuarios/respaldos/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { BackupsPanel } from "@/features/respaldos/presentation/backups-panel";
+
+// La ruta solo monta la pantalla: la logica vive en la feature, segun la regla 8.
+export default function RespaldosPage() {
+  return <BackupsPanel />;
+}

--- a/frontend/src/features/respaldos/application/use-backups-controller.ts
+++ b/frontend/src/features/respaldos/application/use-backups-controller.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { Backup, isValidBackupFileName } from "../domain/backup.model";
+import { BackupRepository, httpBackupRepository } from "../infrastructure/backup.repository";
+
+// Hook controlador: mantiene el estado de la pantalla y coordina las acciones.
+// El repositorio se inyecta para poder sustituirlo en pruebas.
+export function useBackupsController(repository: BackupRepository = httpBackupRepository) {
+  const [backups, setBackups] = useState<Backup[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [downloadingFile, setDownloadingFile] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const loadBackups = useCallback(async () => {
+    setIsLoading(true);
+    setErrorMessage("");
+    try {
+      setBackups(await repository.list());
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "No se pudieron cargar los respaldos",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [repository]);
+
+  useEffect(() => {
+    void loadBackups();
+  }, [loadBackups]);
+
+  async function generateBackup() {
+    // La generacion es sincrona en el servidor y puede tardar: sin este guardia,
+    // un doble clic dispara dos pg_dump concurrentes.
+    if (isGenerating) return;
+
+    setIsGenerating(true);
+    setErrorMessage("");
+    try {
+      await repository.generate();
+      await loadBackups();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Error al generar el respaldo",
+      );
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  async function downloadBackup(fileName: string) {
+    if (!isValidBackupFileName(fileName)) {
+      setErrorMessage("El nombre del respaldo no es válido.");
+      return;
+    }
+
+    setDownloadingFile(fileName);
+    setErrorMessage("");
+
+    let objectUrl: string | null = null;
+    try {
+      const blob = await repository.download(fileName);
+
+      // El endpoint exige cabecera Authorization, asi que no sirve un enlace directo:
+      // se materializa el Blob en un object URL y se dispara un ancla sintetica.
+      objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = fileName;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "No se pudo descargar el respaldo",
+      );
+    } finally {
+      // Revocar siempre: el object URL retiene el Blob en memoria hasta liberarlo.
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+      setDownloadingFile(null);
+    }
+  }
+
+  return {
+    backups,
+    isLoading,
+    isGenerating,
+    downloadingFile,
+    errorMessage,
+    generateBackup,
+    downloadBackup,
+    reload: loadBackups,
+  };
+}

--- a/frontend/src/features/respaldos/domain/backup.model.ts
+++ b/frontend/src/features/respaldos/domain/backup.model.ts
@@ -1,0 +1,55 @@
+// Capa de dominio: tipos y reglas puras. Sin React y sin acceso a red.
+
+export interface Backup {
+  fileName: string;
+  createdAt: string;
+  fileSizeBytes: number;
+}
+
+// Mismo patron que aplica el backend en BackupService.OpenBackup. Se replica aqui
+// para no llegar a pedir al servidor un nombre que ya sabemos que va a rechazar.
+// No es una medida de seguridad: la autoritativa es la del servidor.
+const BACKUP_FILE_NAME = /^backup_\d{8}_\d{4}\.sql$/;
+
+export function isValidBackupFileName(fileName: string): boolean {
+  return BACKUP_FILE_NAME.test(fileName);
+}
+
+const UNITS = ["B", "KB", "MB", "GB"] as const;
+
+export function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "—";
+  if (bytes === 0) return "0 B";
+
+  let value = bytes;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < UNITS.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  // Sin decimales para bytes; con uno para el resto, que basta para comparar respaldos.
+  const rounded = unitIndex === 0 ? String(value) : value.toFixed(1);
+  return `${rounded} ${UNITS[unitIndex]}`;
+}
+
+export function formatBackupDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) return "—";
+
+  return date.toLocaleString("es-HN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// El backend ya devuelve la lista ordenada, pero la vista no debe depender de ello.
+export function sortBackupsByDateDesc(backups: Backup[]): Backup[] {
+  return [...backups].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+}

--- a/frontend/src/features/respaldos/infrastructure/backup.repository.ts
+++ b/frontend/src/features/respaldos/infrastructure/backup.repository.ts
@@ -1,0 +1,26 @@
+import { backupService } from "@/services/backup.service";
+
+import { Backup, sortBackupsByDateDesc } from "../domain/backup.model";
+
+// Capa de infraestructura: traduce entre el servicio HTTP y el dominio.
+// La capa de aplicacion depende de este puerto, no de fetch.
+export interface BackupRepository {
+  list(): Promise<Backup[]>;
+  generate(): Promise<Backup>;
+  download(fileName: string): Promise<Blob>;
+}
+
+export const httpBackupRepository: BackupRepository = {
+  async list() {
+    const data = await backupService.listBackups();
+    return sortBackupsByDateDesc(data);
+  },
+
+  async generate() {
+    return backupService.generateBackup();
+  },
+
+  async download(fileName: string) {
+    return backupService.downloadBackup(fileName);
+  },
+};

--- a/frontend/src/features/respaldos/presentation/backups-panel.tsx
+++ b/frontend/src/features/respaldos/presentation/backups-panel.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import NextLink from "next/link";
+import { Box, Button, Container, HStack, Heading, Stack, Text } from "@chakra-ui/react";
+import { FiDatabase } from "react-icons/fi";
+
+import { useBackupsController } from "../application/use-backups-controller";
+import { BackupsTable } from "./backups-table";
+
+// Navegacion propia de esta pantalla. Las cuatro secciones existentes del panel
+// escriben sus enlaces a mano en cada pagina; aqui solo se enlaza hacia ellas, sin
+// modificarlas. La integracion inversa queda para el responsable de ese modulo.
+const PANEL_LINKS = [
+  { href: "/usuarios", label: "Usuarios" },
+  { href: "/usuarios/registrados", label: "Registrados" },
+  { href: "/usuarios/logs", label: "Bitácora" },
+  { href: "/usuarios/grafica", label: "Gráfica" },
+];
+
+export function BackupsPanel() {
+  const {
+    backups,
+    isLoading,
+    isGenerating,
+    downloadingFile,
+    errorMessage,
+    generateBackup,
+    downloadBackup,
+  } = useBackupsController();
+
+  return (
+    <Container maxW="6xl" py="8">
+      <Stack gap="6">
+        <HStack gap="4" wrap="wrap">
+          {PANEL_LINKS.map((link) => (
+            <NextLink key={link.href} href={link.href} style={{ textDecoration: "none" }}>
+              <Text fontSize="sm" color="fg.muted">
+                {link.label}
+              </Text>
+            </NextLink>
+          ))}
+          <Text fontSize="sm" fontWeight="semibold" data-testid="backups-nav-current">
+            Respaldos
+          </Text>
+        </HStack>
+
+        <HStack justify="space-between" wrap="wrap" gap="4">
+          <Stack gap="1">
+            <Heading size="lg" data-testid="backups-title">
+              Respaldos de base de datos
+            </Heading>
+            <Text fontSize="sm" color="fg.muted">
+              Genera un volcado completo de la base de datos y descárgalo.
+            </Text>
+          </Stack>
+
+          <Button
+            colorPalette="blue"
+            data-testid="generate-backup-button"
+            loading={isGenerating}
+            loadingText="Generando…"
+            onClick={() => void generateBackup()}
+          >
+            <FiDatabase />
+            Generar respaldo
+          </Button>
+        </HStack>
+
+        {/* El respaldo vive en el sistema de archivos del contenedor hasta que se
+            resuelva el issue #126. Sin volumen montado desaparece al desplegar, y
+            sin este aviso eso se lee como un fallo de la aplicacion. */}
+        <Box
+          borderWidth="1px"
+          borderRadius="md"
+          borderColor="orange.300"
+          bg="orange.50"
+          p="3"
+          data-testid="backups-persistence-warning"
+        >
+          <Text fontSize="sm">
+            Los respaldos se guardan en el servidor de la aplicación. Si el servicio se
+            redespliega sin un volumen persistente, esta lista puede aparecer vacía.
+            Descarga los respaldos que quieras conservar.
+          </Text>
+        </Box>
+
+        {errorMessage && (
+          <Box
+            borderWidth="1px"
+            borderRadius="md"
+            borderColor="red.300"
+            bg="red.50"
+            p="3"
+            data-testid="backups-error"
+          >
+            <Text fontSize="sm" color="red.700">
+              {errorMessage}
+            </Text>
+          </Box>
+        )}
+
+        <BackupsTable
+          backups={backups}
+          isLoading={isLoading}
+          downloadingFile={downloadingFile}
+          onDownload={(fileName) => void downloadBackup(fileName)}
+        />
+      </Stack>
+    </Container>
+  );
+}

--- a/frontend/src/features/respaldos/presentation/backups-table.tsx
+++ b/frontend/src/features/respaldos/presentation/backups-table.tsx
@@ -1,0 +1,80 @@
+import { Button, Card, HStack, Table, Text } from "@chakra-ui/react";
+import { FiDownload } from "react-icons/fi";
+
+import { Backup, formatBackupDate, formatFileSize } from "../domain/backup.model";
+
+interface BackupsTableProps {
+  backups: Backup[];
+  isLoading: boolean;
+  downloadingFile: string | null;
+  onDownload: (fileName: string) => void;
+}
+
+export function BackupsTable({
+  backups,
+  isLoading,
+  downloadingFile,
+  onDownload,
+}: BackupsTableProps) {
+  return (
+    <Card.Root>
+      <Card.Header>
+        <HStack justify="space-between">
+          <Text fontWeight="semibold">Respaldos disponibles</Text>
+          <Text fontSize="sm" color="fg.muted" data-testid="backups-count">
+            {backups.length} {backups.length === 1 ? "archivo" : "archivos"}
+          </Text>
+        </HStack>
+      </Card.Header>
+      <Card.Body>
+        {isLoading && <Text data-testid="backups-loading">Cargando respaldos…</Text>}
+
+        {!isLoading && backups.length === 0 && (
+          <Text color="fg.muted" data-testid="backups-empty">
+            Todavía no hay respaldos generados. Usa «Generar respaldo» para crear el primero.
+          </Text>
+        )}
+
+        {!isLoading && backups.length > 0 && (
+          <Table.Root variant="outline" size="sm">
+            <Table.Header>
+              <Table.Row>
+                <Table.ColumnHeader>Archivo</Table.ColumnHeader>
+                <Table.ColumnHeader>Fecha de creación</Table.ColumnHeader>
+                <Table.ColumnHeader>Tamaño</Table.ColumnHeader>
+                <Table.ColumnHeader textAlign="right">Acciones</Table.ColumnHeader>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {backups.map((backup) => (
+                <Table.Row key={backup.fileName} data-testid="backup-row">
+                  <Table.Cell>
+                    <Text fontWeight="semibold" data-testid="backup-filename">
+                      {backup.fileName}
+                    </Text>
+                  </Table.Cell>
+                  <Table.Cell>{formatBackupDate(backup.createdAt)}</Table.Cell>
+                  <Table.Cell data-testid="backup-size">
+                    {formatFileSize(backup.fileSizeBytes)}
+                  </Table.Cell>
+                  <Table.Cell textAlign="right">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      data-testid="backup-download-button"
+                      loading={downloadingFile === backup.fileName}
+                      onClick={() => onDownload(backup.fileName)}
+                    >
+                      <FiDownload />
+                      Descargar
+                    </Button>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table.Root>
+        )}
+      </Card.Body>
+    </Card.Root>
+  );
+}

--- a/frontend/src/services/backup.service.ts
+++ b/frontend/src/services/backup.service.ts
@@ -1,0 +1,49 @@
+const apiUrl = process.env.NEXT_PUBLIC_ALLOWED_PATH;
+
+const getToken = () =>
+  typeof window !== "undefined" ? localStorage.getItem("token") : null;
+
+const authHeaders = () => ({
+  "Content-Type": "application/json",
+  Authorization: `Bearer ${getToken()}`,
+});
+
+export type BackupData = {
+  fileName: string;
+  createdAt: string;
+  fileSizeBytes: number;
+};
+
+export const backupService = {
+  async listBackups(): Promise<BackupData[]> {
+    const res = await fetch(`${apiUrl}/api/Admin/backups`, {
+      headers: authHeaders(),
+    });
+    if (!res.ok) throw new Error("No se pudieron cargar los respaldos");
+    return res.json();
+  },
+
+  async generateBackup(): Promise<BackupData> {
+    const res = await fetch(`${apiUrl}/api/Admin/backup`, {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.message ?? "Error al generar el respaldo");
+    }
+    return res.json();
+  },
+
+  // La descarga no puede ser un <a href> normal: el endpoint exige la cabecera
+  // Authorization y el navegador no la adjunta en una navegacion. Se pide con
+  // fetch y se devuelve el Blob para que la capa superior lo materialice.
+  async downloadBackup(fileName: string): Promise<Blob> {
+    const res = await fetch(
+      `${apiUrl}/api/Admin/backups/${encodeURIComponent(fileName)}`,
+      { headers: { Authorization: `Bearer ${getToken()}` } },
+    );
+    if (!res.ok) throw new Error("No se pudo descargar el respaldo");
+    return res.blob();
+  },
+};

--- a/frontend/tests/respaldos.spec.ts
+++ b/frontend/tests/respaldos.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, Page } from '@playwright/test';
+
+const RESPALDOS_URL = 'http://localhost:3000/usuarios/respaldos';
+
+const backupsFixture = [
+  { fileName: 'backup_20260813_1537.sql', createdAt: '2026-08-13T15:37:14Z', fileSizeBytes: 18651 },
+  { fileName: 'backup_20260812_0900.sql', createdAt: '2026-08-12T09:00:00Z', fileSizeBytes: 2048 },
+];
+
+/** Sesion simulada: las paginas de administracion leen el token de localStorage. */
+async function authenticate(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('token', 'fake-token');
+  });
+}
+
+/** Mockea el listado. El patron `**` cubre la URL absoluta del backend. */
+async function mockList(page: Page, body: unknown, status = 200) {
+  await page.route('**/api/Admin/backups', async route => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    await route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+}
+
+test.describe('Panel de respaldos', () => {
+  test('muestra la lista de respaldos existentes', async ({ page }) => {
+    await authenticate(page);
+    await mockList(page, backupsFixture);
+
+    await page.goto(RESPALDOS_URL);
+
+    await expect(page.getByTestId('backups-title')).toBeVisible();
+    await expect(page.getByTestId('backup-row')).toHaveCount(2);
+    await expect(page.getByTestId('backup-filename').first()).toHaveText('backup_20260813_1537.sql');
+    await expect(page.getByTestId('backups-count')).toHaveText('2 archivos');
+  });
+
+  test('formatea el tamano en unidades legibles y no en bytes crudos', async ({ page }) => {
+    await authenticate(page);
+    await mockList(page, backupsFixture);
+
+    await page.goto(RESPALDOS_URL);
+
+    // 18651 B -> 18.2 KB ; 2048 B -> 2.0 KB
+    await expect(page.getByTestId('backup-size').first()).toHaveText('18.2 KB');
+    await expect(page.getByTestId('backup-size').nth(1)).toHaveText('2.0 KB');
+  });
+
+  test('muestra estado vacio cuando no hay respaldos', async ({ page }) => {
+    await authenticate(page);
+    await mockList(page, []);
+
+    await page.goto(RESPALDOS_URL);
+
+    await expect(page.getByTestId('backups-empty')).toBeVisible();
+    await expect(page.getByTestId('backup-row')).toHaveCount(0);
+  });
+
+  test('advierte que los respaldos pueden perderse al redesplegar', async ({ page }) => {
+    await authenticate(page);
+    await mockList(page, []);
+
+    await page.goto(RESPALDOS_URL);
+
+    await expect(page.getByTestId('backups-persistence-warning')).toBeVisible();
+  });
+
+  test('generar un respaldo refresca la lista', async ({ page }) => {
+    await authenticate(page);
+
+    let listCalls = 0;
+    await page.route('**/api/Admin/backups', async route => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      listCalls += 1;
+      // La primera carga esta vacia; tras generar, la lista ya trae el archivo.
+      const body = listCalls === 1 ? [] : [backupsFixture[0]];
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    });
+
+    await page.route('**/api/Admin/backup', async route => {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify(backupsFixture[0]),
+      });
+    });
+
+    await page.goto(RESPALDOS_URL);
+    await expect(page.getByTestId('backups-empty')).toBeVisible();
+
+    await page.getByTestId('generate-backup-button').click();
+
+    await expect(page.getByTestId('backup-row')).toHaveCount(1);
+    await expect(page.getByTestId('backup-filename')).toHaveText('backup_20260813_1537.sql');
+  });
+
+  test('muestra el error cuando la generacion falla', async ({ page }) => {
+    await authenticate(page);
+    await mockList(page, []);
+
+    await page.route('**/api/Admin/backup', async route => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'No se pudo generar el respaldo de la base de datos.' }),
+      });
+    });
+
+    await page.goto(RESPALDOS_URL);
+    await page.getByTestId('generate-backup-button').click();
+
+    await expect(page.getByTestId('backups-error')).toBeVisible();
+    await expect(page.getByTestId('backups-error')).toContainText('No se pudo generar el respaldo');
+  });
+
+  test('muestra el error cuando el listado falla', async ({ page }) => {
+    await authenticate(page);
+    await mockList(page, { message: 'no autorizado' }, 403);
+
+    await page.goto(RESPALDOS_URL);
+
+    await expect(page.getByTestId('backups-error')).toBeVisible();
+  });
+
+  test('la descarga pide el archivo con cabecera Authorization', async ({ page }) => {
+    await authenticate(page);
+    await mockList(page, [backupsFixture[0]]);
+
+    let authHeader: string | undefined;
+    await page.route('**/api/Admin/backups/backup_20260813_1537.sql', async route => {
+      authHeader = route.request().headers()['authorization'];
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/octet-stream',
+        body: '-- volcado de prueba',
+      });
+    });
+
+    await page.goto(RESPALDOS_URL);
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByTestId('backup-download-button').click();
+    const download = await downloadPromise;
+
+    // Lo que se verifica no es solo que descargue, sino que lleve el token:
+    // un <a href> plano devolveria 401 porque el navegador no lo adjunta.
+    expect(authHeader).toBe('Bearer fake-token');
+    expect(download.suggestedFilename()).toBe('backup_20260813_1537.sql');
+  });
+});


### PR DESCRIPTION
## 📌 Resumen del Cambio

Añade `/usuarios/respaldos` al panel de administración: listar los respaldos existentes, generar uno nuevo y descargar el `.sql`.

Los tres endpoints quedaron funcionando y verificados en #133, pero hasta ahora solo eran accesibles desde Swagger pegando un JWT a mano. El reporte de auditoría describe el respaldo como capacidad del rol Admin junto a otras cuatro que sí tienen pantalla; esta cierra esa brecha.

Depende de #133, ya mergeado en `dev` (PR #157).

---

## 🔍 Tipo de Cambio realizado

- [ ] 🐞 Corrección de error (`fix`)
- [x] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [x] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

Todos son **archivos nuevos**. No se modifica ningún archivo existente.

```
frontend/src/services/backup.service.ts                          HTTP
frontend/src/features/respaldos/
  domain/backup.model.ts                                         tipos + formato + validación
  infrastructure/backup.repository.ts                            puerto sobre el servicio
  application/use-backups-controller.ts                          hook controlador
  presentation/backups-table.tsx                                 tabla
  presentation/backups-panel.tsx                                 pantalla + navegación propia
frontend/app/usuarios/respaldos/page.tsx                         ruta
frontend/tests/respaldos.spec.ts                                 8 specs
```

---

## 🧪 ¿Cómo Probarlo?

```bash
cd frontend
npm install
npm run dev
```

Entrar a `http://localhost:3000/usuarios/respaldos` con sesión de administrador. Requiere la API levantada (`dotnet run --project backend/SistemaServicios.API`) y `pg_dump` en el `PATH`.

Qué debería verse:

1. La tabla lista los respaldos existentes con fecha y tamaño en unidades legibles, o un estado vacío si no hay ninguno.
2. **Generar respaldo** deshabilita el botón mientras trabaja y, al terminar, la lista se refresca sola con el archivo nuevo.
3. **Descargar** entrega el `.sql` con su nombre correcto.
4. Un aviso naranja advierte que los respaldos pueden perderse al redesplegar.

Pruebas automatizadas:

```bash
cd frontend && npx playwright test tests/respaldos.spec.ts
```

---

## ✅ Checklist

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [x] Se han actualizado o agregado pruebas
- [x] La documentación se actualizó si fue necesario
- [x] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Closes #158

### Arquitectura: se sigue la regla 8

`.CLAUDE/RULES.md` exige el corte de `src/features/solicitudes/`. El issue planteaba una disyuntiva —seguir la regla o imitar las páginas de administración existentes, que no la cumplen— y se resolvió **por la regla**, sin tocar el panel actual:

- **domain** — tipos y funciones puras: formato de tamaño y fecha, orden y validación de nombre. Sin React ni red.
- **infrastructure** — puerto `BackupRepository` sobre el servicio HTTP.
- **application** — hook controlador con el repositorio **inyectable**, para poder sustituirlo en pruebas sin red.
- **presentation** — componentes sin lógica de negocio.

La llamada HTTP vive en `src/services/` y toma la URL base de `NEXT_PUBLIC_ALLOWED_PATH`.

### La descarga no puede ser un enlace directo

El endpoint exige la cabecera `Authorization`, que el navegador **no** adjunta en una navegación normal: un `<a href>` plano devolvería 401. Se pide con `fetch`, se materializa el `Blob` en un object URL y se dispara un ancla sintética, revocando el object URL siempre al terminar.

La spec correspondiente **verifica que la petición lleve la cabecera**, no solo que el archivo se descargue. Si alguien simplifica esto a un enlace plano, la prueba falla en vez de romper en producción.

### Guardia contra generaciones concurrentes

El endpoint de generación es síncrono y puede tardar. El botón se bloquea mientras hay una generación en curso: sin ese guardia, un doble clic dispara dos `pg_dump` concurrentes.

### La pantalla no es alcanzable desde el panel actual

Es deliberado y fue acordado. La sub-navegación del panel está **duplicada a mano en cuatro archivos** (`app/usuarios/page.tsx`, `logs/page.tsx`, `registrados/page.tsx`, `registrados_page.tsx`); no hay layout compartido. Enlazar esta pantalla obligaría a modificarlos, así que se dejó fuera del alcance.

Se entra por `/usuarios/respaldos`, y desde ahí se navega a las otras cuatro secciones. **La integración inversa corresponde al responsable de ese módulo.** Extraer esa navegación a un componente único sería el arreglo de fondo.

### Aviso de persistencia en la interfaz

Mientras #126 siga abierto, los respaldos viven en el sistema de archivos del contenedor. Sin volumen montado, la lista aparece vacía tras un redespliegue. La pantalla lo advierte para que eso no se lea como un fallo de la aplicación.

### Sobre la autorización

No existe `middleware.ts` ni guarda por rol en el cliente: quien autoriza es el backend, que responde 403. Esta pantalla hereda ese comportamiento y **no** introduce una guarda propia que pudiera confundirse con seguridad real.

### Verificación

- `npm run build` correcto, con `/usuarios/respaldos` en las rutas generadas.
- Playwright: **102/102**, incluidas las 8 specs nuevas. Ejecutado sobre la rama ya rebasada en `dev`.

### Dos apuntes que exceden esta PR

**`npm run lint` está roto en el repositorio y no por este cambio.** ESLint falla al arrancar con `Cannot find module 'ajv/lib/refs/json-schema-draft-04.json'`, dentro de su propio `lib/shared/ajv.js`, antes de analizar ningún archivo. Se comprobó sobre `app/login/page.tsx`, que esta PR no toca: falla idéntico. La causa es el `overrides: { "ajv": "^8.18.0" }` de `package.json`. Conviene resolverlo antes de cerrar #129, porque un workflow que ejecute `npm run lint` fallaría hoy por algo ajeno al código.

**La suite tiene un flake.** En una de las pasadas falló `grafica.spec.ts › Link CRUD navega a /usuarios`; en aislamiento pasan las diez y las pasadas siguientes dieron 102/102. No hay `playwright.config.ts` —eso es #129—, así que no hay reintentos configurados y los flakes se manifiestan directamente.
