### PR TITLE
feat(backend): almacena los avatares en base de datos tras IFileStorage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,12 @@ ALLOWED_ORIGINS=http://localhost:3000
 
 NEXT_PUBLIC_ALLOWED_PATH=http://localhost:5000
 
+# Almacenamiento de archivos subidos (avatares).
+# Sin definir o con cualquier otro valor: se guardan en la base de datos, que es
+# lo que permite que sobrevivan a un despliegue y sean visibles desde cualquier
+# réplica. Con "local": se guardan en wwwroot, solo para desarrollo.
+FILE_STORAGE=
+
 # Destino de los respaldos de base de datos.
 # Si se omite, se usa <directorio de trabajo>/backups.
 # En el contenedor conviene apuntarlo a un volumen montado: sin montaje, el .sql

--- a/backend/SistemaServicios.API/Controllers/FilesController.cs
+++ b/backend/SistemaServicios.API/Controllers/FilesController.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SistemaServicios.API.Interfaces;
+
+namespace SistemaServicios.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class FilesController : ControllerBase
+{
+    private readonly IFileStorage _fileStorage;
+
+    public FilesController(IFileStorage fileStorage)
+    {
+        _fileStorage = fileStorage;
+    }
+
+    /// <summary>
+    /// Sirve un archivo almacenado. Anónimo: los avatares se muestran en el catálogo
+    /// público, que se consulta sin iniciar sesión.
+    /// </summary>
+    [HttpGet("{id:guid}")]
+    [AllowAnonymous]
+    public async Task<IActionResult> GetFile(Guid id, CancellationToken cancellationToken)
+    {
+        var file = await _fileStorage.GetAsync(id, cancellationToken);
+
+        if (file is null)
+        {
+            return NotFound();
+        }
+
+        // Cacheable de forma agresiva porque el identificador cambia en cada subida:
+        // reemplazar el avatar produce una URL nueva, así que no hay que invalidar nada.
+        Response.Headers.CacheControl = "public, max-age=31536000, immutable";
+
+        return File(file.Content, file.ContentType);
+    }
+}

--- a/backend/SistemaServicios.API/Data/AppDbContext.cs
+++ b/backend/SistemaServicios.API/Data/AppDbContext.cs
@@ -24,6 +24,8 @@ public class AppDbContext : DbContext
 
     public DbSet<UserLog> UserLogs { get; set; }
 
+    public DbSet<StoredFile> StoredFiles { get; set; }
+
     // Configuración especial de relaciones (Fluent API)
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -70,5 +72,18 @@ public class AppDbContext : DbContext
             .WithMany()
             .HasForeignKey(l => l.UserId)
             .OnDelete(DeleteBehavior.Restrict);
+
+        // StoredFile: mismo criterio que el resto, sin borrado en cascada.
+        // El borrado de usuarios es lógico, así que sus archivos se conservan.
+        modelBuilder
+            .Entity<StoredFile>()
+            .HasOne(f => f.Owner)
+            .WithMany()
+            .HasForeignKey(f => f.OwnerUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // El reemplazo de avatar busca por dueño: sin índice sería un scan completo
+        // de una tabla que guarda binarios.
+        modelBuilder.Entity<StoredFile>().HasIndex(f => f.OwnerUserId);
     }
 }

--- a/backend/SistemaServicios.API/Extensions/ApplicationServiceExtensions.cs
+++ b/backend/SistemaServicios.API/Extensions/ApplicationServiceExtensions.cs
@@ -80,6 +80,20 @@ public static class ApplicationServiceExtensions
         services.AddScoped<IAuthService, AuthService>();
         services.AddScoped<IProcessRunner, ProcessRunner>();
         services.AddScoped<IBackupService, BackupService>();
+
+        // Almacenamiento de archivos: la base de datos por defecto, porque el disco
+        // del contenedor es efímero y no se comparte entre réplicas. FILE_STORAGE=local
+        // recupera el comportamiento en disco para desarrollo.
+        var fileStorage = Environment.GetEnvironmentVariable("FILE_STORAGE");
+        if (string.Equals(fileStorage, "local", StringComparison.OrdinalIgnoreCase))
+        {
+            services.AddScoped<IFileStorage, LocalFileStorage>();
+        }
+        else
+        {
+            services.AddScoped<IFileStorage, DbFileStorage>();
+        }
+
         services.AddScoped<IUserService, UserService>();
         services.AddScoped<IRatingService, RatingService>();
         services.AddScoped<IServiceRequestRepository, ServiceRequestRepository>();

--- a/backend/SistemaServicios.API/Interfaces/IFileStorage.cs
+++ b/backend/SistemaServicios.API/Interfaces/IFileStorage.cs
@@ -1,0 +1,28 @@
+namespace SistemaServicios.API.Interfaces;
+
+/// <summary>
+/// Almacenamiento de archivos binarios. Existe para que los servicios de negocio no
+/// conozcan dónde viven los archivos: hoy es la base de datos, mañana puede ser un
+/// object storage sin tocar a quien la consume.
+/// </summary>
+public interface IFileStorage
+{
+    /// <summary>
+    /// Guarda el archivo y devuelve la ruta relativa con la que se sirve.
+    /// Reemplaza cualquier archivo anterior del mismo dueño.
+    /// </summary>
+    public Task<string> SaveForOwnerAsync(
+        Guid ownerUserId,
+        Stream content,
+        string contentType,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Recupera un archivo por identificador. Devuelve <c>null</c> si no existe.
+    /// </summary>
+    public Task<StoredFileContent?> GetAsync(
+        Guid fileId,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/backend/SistemaServicios.API/Interfaces/StoredFileContent.cs
+++ b/backend/SistemaServicios.API/Interfaces/StoredFileContent.cs
@@ -1,0 +1,6 @@
+namespace SistemaServicios.API.Interfaces;
+
+/// <summary>
+/// Contenido de un archivo recuperado del almacenamiento.
+/// </summary>
+public record StoredFileContent(byte[] Content, string ContentType);

--- a/backend/SistemaServicios.API/Migrations/20260813184350_AddStoredFiles.Designer.cs
+++ b/backend/SistemaServicios.API/Migrations/20260813184350_AddStoredFiles.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SistemaServicios.API.Data;
@@ -11,9 +12,11 @@ using SistemaServicios.API.Data;
 namespace SistemaServicios.API.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260813184350_AddStoredFiles")]
+    partial class AddStoredFiles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/SistemaServicios.API/Migrations/20260813184350_AddStoredFiles.cs
+++ b/backend/SistemaServicios.API/Migrations/20260813184350_AddStoredFiles.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SistemaServicios.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStoredFiles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "StoredFiles",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Content = table.Column<byte[]>(type: "bytea", nullable: false),
+                    ContentType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    SizeBytes = table.Column<long>(type: "bigint", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StoredFiles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_StoredFiles_Users_OwnerUserId",
+                        column: x => x.OwnerUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StoredFiles_OwnerUserId",
+                table: "StoredFiles",
+                column: "OwnerUserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "StoredFiles");
+        }
+    }
+}

--- a/backend/SistemaServicios.API/Models/StoredFile.cs
+++ b/backend/SistemaServicios.API/Models/StoredFile.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace SistemaServicios.API.Models;
+
+/// <summary>
+/// Archivo binario guardado en la base de datos.
+/// Vive en su propia tabla y no como columna de User para que las consultas de
+/// usuarios no arrastren los bytes de la imagen en cada lectura.
+/// </summary>
+public class StoredFile
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Dueño del archivo. Permite reemplazar el avatar borrando por usuario, sin
+    /// tener que deducir el identificador anterior desde la URL.
+    /// </summary>
+    public Guid OwnerUserId { get; set; }
+
+    [ForeignKey(nameof(OwnerUserId))]
+    public User? Owner { get; set; }
+
+    public byte[] Content { get; set; } = [];
+
+    [MaxLength(100)]
+    public string ContentType { get; set; } = string.Empty;
+
+    public long SizeBytes { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/SistemaServicios.API/Services/DbFileStorage.cs
+++ b/backend/SistemaServicios.API/Services/DbFileStorage.cs
@@ -1,0 +1,76 @@
+using Microsoft.EntityFrameworkCore;
+using SistemaServicios.API.Data;
+using SistemaServicios.API.Interfaces;
+using SistemaServicios.API.Models;
+
+namespace SistemaServicios.API.Services;
+
+/// <summary>
+/// Guarda los archivos en PostgreSQL. Al vivir en la base y no en el disco del
+/// contenedor, los avatares sobreviven a los despliegues y son visibles desde
+/// cualquier réplica, que es lo que impedía el escalado horizontal.
+/// </summary>
+public class DbFileStorage : IFileStorage
+{
+    private readonly AppDbContext _context;
+
+    public DbFileStorage(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<string> SaveForOwnerAsync(
+        Guid ownerUserId,
+        Stream content,
+        string contentType,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        using var buffer = new MemoryStream();
+        await content.CopyToAsync(buffer, cancellationToken);
+        var bytes = buffer.ToArray();
+
+        // Se borra lo anterior del mismo dueño: sin esto, cada cambio de avatar
+        // dejaría una fila huérfana con su binario dentro.
+        var previous = await _context
+            .StoredFiles.Where(f => f.OwnerUserId == ownerUserId)
+            .ToListAsync(cancellationToken);
+
+        if (previous.Count > 0)
+        {
+            _context.StoredFiles.RemoveRange(previous);
+        }
+
+        var stored = new StoredFile
+        {
+            Id = Guid.NewGuid(),
+            OwnerUserId = ownerUserId,
+            Content = bytes,
+            ContentType = contentType,
+            SizeBytes = bytes.LongLength,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        _ = await _context.StoredFiles.AddAsync(stored, cancellationToken);
+        _ = await _context.SaveChangesAsync(cancellationToken);
+
+        // Ruta relativa: el frontend la concatena a la URL base de la API.
+        return $"/api/Files/{stored.Id}";
+    }
+
+    public async Task<StoredFileContent?> GetAsync(
+        Guid fileId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var file = await _context
+            .StoredFiles.AsNoTracking()
+            .Where(f => f.Id == fileId)
+            .Select(f => new StoredFileContent(f.Content, f.ContentType))
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return file;
+    }
+}

--- a/backend/SistemaServicios.API/Services/LocalFileStorage.cs
+++ b/backend/SistemaServicios.API/Services/LocalFileStorage.cs
@@ -1,0 +1,64 @@
+using SistemaServicios.API.Interfaces;
+
+namespace SistemaServicios.API.Services;
+
+/// <summary>
+/// Guarda los archivos en wwwroot. Conserva el comportamiento previo a la migración
+/// a base de datos y solo debe usarse en desarrollo: el disco del contenedor es
+/// efímero y no se comparte entre réplicas.
+/// </summary>
+public class LocalFileStorage : IFileStorage
+{
+    private static readonly Dictionary<string, string> ExtensionByContentType = new(
+        StringComparer.OrdinalIgnoreCase
+    )
+    {
+        ["image/png"] = ".png",
+        ["image/jpeg"] = ".jpg",
+    };
+
+    private readonly IWebHostEnvironment _env;
+
+    public LocalFileStorage(IWebHostEnvironment env)
+    {
+        _env = env;
+    }
+
+    public async Task<string> SaveForOwnerAsync(
+        Guid ownerUserId,
+        Stream content,
+        string contentType,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        var uploadsDir = Path.Combine(_env.WebRootPath, "uploads", "avatars");
+        _ = Directory.CreateDirectory(uploadsDir);
+
+        var extension = ExtensionByContentType.TryGetValue(contentType, out var known)
+            ? known
+            : ".bin";
+
+        // El nombre depende del dueño, así que una subida nueva sobrescribe la anterior.
+        var fileName = $"{ownerUserId}{extension}";
+        var filePath = Path.Combine(uploadsDir, fileName);
+
+        await using (var stream = new FileStream(filePath, FileMode.Create))
+        {
+            await content.CopyToAsync(stream, cancellationToken);
+        }
+
+        return $"/uploads/avatars/{fileName}";
+    }
+
+    public Task<StoredFileContent?> GetAsync(
+        Guid fileId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        // Los archivos locales se sirven como estáticos desde wwwroot, no por el
+        // endpoint de descarga; no hay nada que resolver por identificador.
+        return Task.FromResult<StoredFileContent?>(null);
+    }
+}

--- a/backend/SistemaServicios.API/Services/UserService.cs
+++ b/backend/SistemaServicios.API/Services/UserService.cs
@@ -12,17 +12,17 @@ public class UserService : IUserService
     private static readonly string[] AllowedImageMimeTypes = ["image/jpeg", "image/png"];
 
     private readonly IUserRepository _userRepository;
-    private readonly IWebHostEnvironment _env;
+    private readonly IFileStorage _fileStorage;
     private readonly IUserLogService _logService;
 
     public UserService(
         IUserRepository userRepository,
-        IWebHostEnvironment env,
+        IFileStorage fileStorage,
         IUserLogService logService
     )
     {
         _userRepository = userRepository;
-        _env = env;
+        _fileStorage = fileStorage;
         _logService = logService;
     }
 
@@ -221,19 +221,13 @@ public class UserService : IUserService
             throw new InvalidOperationException("La imagen no puede superar los 2 MB.");
         }
 
-        var ext = foto.ContentType == "image/png" ? ".png" : ".jpg";
-        var uploadsDir = Path.Combine(_env.WebRootPath, "uploads", "avatars");
-        Directory.CreateDirectory(uploadsDir);
-
-        var fileName = $"{userId}{ext}";
-        var filePath = Path.Combine(uploadsDir, fileName);
-
-        await using (var stream = new FileStream(filePath, FileMode.Create))
-        {
-            await foto.CopyToAsync(stream);
-        }
-
-        user.ProfileImageUrl = $"/uploads/avatars/{fileName}";
+        // El servicio no decide dónde vive el archivo: eso es del almacenamiento.
+        await using var contenido = foto.OpenReadStream();
+        user.ProfileImageUrl = await _fileStorage.SaveForOwnerAsync(
+            userId,
+            contenido,
+            foto.ContentType
+        );
         user.UpdatedAt = DateTime.UtcNow;
 
         await _userRepository.UpdateUserAsync(user);

--- a/backend/SistemaServicios.Tests/Integration/FilesControllerTests.cs
+++ b/backend/SistemaServicios.Tests/Integration/FilesControllerTests.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using SistemaServicios.API.Interfaces;
+using Xunit;
+
+namespace SistemaServicios.Tests.Integration;
+
+/// <summary>
+/// Factory que sustituye el almacenamiento por un mock, para no depender de que
+/// haya archivos reales en la base de pruebas.
+/// </summary>
+public class FilesWebApplicationFactory : CustomWebApplicationFactory
+{
+    public Mock<IFileStorage> FileStorageMock { get; } = new();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+
+        _ = builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IFileStorage));
+            if (descriptor != null)
+            {
+                _ = services.Remove(descriptor);
+            }
+
+            _ = services.AddScoped<IFileStorage>(_ => FileStorageMock.Object);
+        });
+    }
+}
+
+public class FilesControllerTests : IClassFixture<FilesWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly Mock<IFileStorage> _storageMock;
+
+    public FilesControllerTests(FilesWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+        _storageMock = factory.FileStorageMock;
+    }
+
+    [Fact]
+    public async Task GetFileSinTokenDevuelveElArchivo()
+    {
+        // Arrange: el endpoint es anónimo a propósito, porque los avatares se
+        // muestran en el catálogo público, que se consulta sin iniciar sesión.
+        var id = Guid.NewGuid();
+        _ = _storageMock
+            .Setup(s => s.GetAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StoredFileContent([1, 2, 3], "image/png"));
+
+        // Act
+        var response = await _client.GetAsync(new Uri($"/api/Files/{id}", UriKind.Relative));
+
+        // Assert
+        _ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _ = response.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        _ = bytes.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public async Task GetFileDevuelveCacheInmutable()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        _ = _storageMock
+            .Setup(s => s.GetAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StoredFileContent([9], "image/jpeg"));
+
+        // Act
+        var response = await _client.GetAsync(new Uri($"/api/Files/{id}", UriKind.Relative));
+
+        // Assert: se puede cachear de forma agresiva porque el id cambia en cada subida
+        var cacheControl = response.Headers.CacheControl?.ToString() ?? string.Empty;
+        _ = cacheControl.Should().Contain("max-age=31536000");
+        _ = cacheControl.Should().Contain("immutable");
+    }
+
+    [Fact]
+    public async Task GetFileConIdInexistenteDevuelve404()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        _ = _storageMock
+            .Setup(s => s.GetAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StoredFileContent?)null);
+
+        // Act
+        var response = await _client.GetAsync(new Uri($"/api/Files/{id}", UriKind.Relative));
+
+        // Assert
+        _ = response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetFileConIdMalFormadoDevuelve404()
+    {
+        // Arrange & Act: la restricción :guid de la ruta descarta el valor
+        var response = await _client.GetAsync(
+            new Uri("/api/Files/no-es-un-guid", UriKind.Relative)
+        );
+
+        // Assert
+        _ = response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/backend/SistemaServicios.Tests/Integration/ProfileControllerTests.cs
+++ b/backend/SistemaServicios.Tests/Integration/ProfileControllerTests.cs
@@ -239,7 +239,16 @@ public class ProfileControllerTests : IClassFixture<CustomWebApplicationFactory>
 
         res.StatusCode.Should().Be(HttpStatusCode.OK);
         var user = await res.Content.ReadFromJsonAsync<UserDto>();
-        user!.ProfileImageUrl.Should().Contain("/uploads/avatars/");
+
+        // La imagen ya no vive en el disco del contenedor: la URL apunta al endpoint
+        // que la sirve desde la base de datos. Antes esta aserción esperaba
+        // "/uploads/avatars/"; se invierte a propósito como parte del issue #125.
+        user!.ProfileImageUrl.Should().StartWith("/api/Files/");
+
+        // Y se comprueba que la imagen se recupera de verdad por esa URL, sin token.
+        var imagen = await _client.GetAsync(new Uri(user.ProfileImageUrl!, UriKind.Relative));
+        imagen.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await imagen.Content.ReadAsByteArrayAsync()).Should().NotBeEmpty();
     }
 
     [Fact]
@@ -260,7 +269,13 @@ public class ProfileControllerTests : IClassFixture<CustomWebApplicationFactory>
 
         res.StatusCode.Should().Be(HttpStatusCode.OK);
         var user = await res.Content.ReadFromJsonAsync<UserDto>();
-        user!.ProfileImageUrl.Should().EndWith(".png");
+
+        // La extensión dejó de formar parte de la URL: el tipo viaja en la cabecera
+        // Content-Type de la respuesta del endpoint, no en el nombre.
+        user!.ProfileImageUrl.Should().StartWith("/api/Files/");
+
+        var imagen = await _client.GetAsync(new Uri(user.ProfileImageUrl!, UriKind.Relative));
+        imagen.Content.Headers.ContentType?.MediaType.Should().Be("image/png");
     }
 
     [Fact]

--- a/backend/SistemaServicios.Tests/Unit/DbFileStorageTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/DbFileStorageTests.cs
@@ -1,0 +1,148 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SistemaServicios.API.Data;
+using SistemaServicios.API.Models;
+using SistemaServicios.API.Services;
+using Xunit;
+
+namespace SistemaServicios.Tests.Unit;
+
+/// <summary>
+/// Pruebas del almacenamiento en base de datos, que es lo que permite que los
+/// avatares sobrevivan a un despliegue y sean visibles desde cualquier réplica.
+/// </summary>
+public class DbFileStorageTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly DbFileStorage _storage;
+    private readonly Guid _ownerId = Guid.NewGuid();
+
+    public DbFileStorageTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase($"FilesTestDb_{Guid.NewGuid()}")
+            .Options;
+
+        _context = new AppDbContext(options);
+        _storage = new DbFileStorage(_context);
+
+        _ = _context.Users.Add(
+            new User
+            {
+                Id = _ownerId,
+                Email = "duenio@test.com",
+                PasswordHash = "hash",
+                FirstName = "Due",
+                LastName = "Nio",
+                Role = UserRole.Client,
+                Status = true,
+            }
+        );
+        _ = _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static MemoryStream Contenido(params byte[] bytes) => new(bytes);
+
+    [Fact]
+    public async Task SaveForOwnerAsyncDevuelveUnaRutaRelativaDeLaApi()
+    {
+        // Act
+        var url = await _storage.SaveForOwnerAsync(_ownerId, Contenido(1, 2, 3), "image/png");
+
+        // Assert: relativa, porque el frontend la concatena a la URL base de la API
+        _ = url.Should().StartWith("/api/Files/");
+        _ = Guid.TryParse(url.Replace("/api/Files/", string.Empty, StringComparison.Ordinal), out _)
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public async Task SaveForOwnerAsyncGuardaContenidoTipoYTamano()
+    {
+        // Act
+        await _storage.SaveForOwnerAsync(_ownerId, Contenido(10, 20, 30, 40), "image/jpeg");
+
+        // Assert
+        var guardado = await _context.StoredFiles.SingleAsync();
+        _ = guardado.Content.Should().Equal(10, 20, 30, 40);
+        _ = guardado.ContentType.Should().Be("image/jpeg");
+        _ = guardado.SizeBytes.Should().Be(4);
+        _ = guardado.OwnerUserId.Should().Be(_ownerId);
+    }
+
+    [Fact]
+    public async Task SaveForOwnerAsyncSegundaSubidaReemplazaLaAnterior()
+    {
+        // Arrange
+        var primeraUrl = await _storage.SaveForOwnerAsync(_ownerId, Contenido(1), "image/jpeg");
+
+        // Act: el cambio de jpg a png es justo el caso que antes dejaba un huérfano
+        var segundaUrl = await _storage.SaveForOwnerAsync(_ownerId, Contenido(2), "image/png");
+
+        // Assert: queda exactamente un archivo, el nuevo
+        _ = _context.StoredFiles.Should().ContainSingle();
+        var guardado = await _context.StoredFiles.SingleAsync();
+        _ = guardado.ContentType.Should().Be("image/png");
+        _ = segundaUrl.Should().NotBe(primeraUrl);
+    }
+
+    [Fact]
+    public async Task SaveForOwnerAsyncNoBorraLosArchivosDeOtrosUsuarios()
+    {
+        // Arrange
+        var otroId = Guid.NewGuid();
+        _ = _context.Users.Add(
+            new User
+            {
+                Id = otroId,
+                Email = "otro@test.com",
+                PasswordHash = "hash",
+                FirstName = "Otro",
+                LastName = "Usuario",
+                Role = UserRole.Client,
+                Status = true,
+            }
+        );
+        _ = await _context.SaveChangesAsync();
+
+        await _storage.SaveForOwnerAsync(otroId, Contenido(9), "image/png");
+
+        // Act
+        await _storage.SaveForOwnerAsync(_ownerId, Contenido(1), "image/png");
+
+        // Assert
+        _ = _context.StoredFiles.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetAsyncDevuelveElContenidoYSuTipo()
+    {
+        // Arrange
+        var url = await _storage.SaveForOwnerAsync(_ownerId, Contenido(7, 8), "image/jpeg");
+        var id = Guid.Parse(url.Replace("/api/Files/", string.Empty, StringComparison.Ordinal));
+
+        // Act
+        var archivo = await _storage.GetAsync(id);
+
+        // Assert
+        _ = archivo.Should().NotBeNull();
+        _ = archivo!.Content.Should().Equal(7, 8);
+        _ = archivo.ContentType.Should().Be("image/jpeg");
+    }
+
+    [Fact]
+    public async Task GetAsyncConIdInexistenteDevuelveNull()
+    {
+        // Act
+        var archivo = await _storage.GetAsync(Guid.NewGuid());
+
+        // Assert
+        _ = archivo.Should().BeNull();
+    }
+}

--- a/backend/SistemaServicios.Tests/Unit/ProfileServiceTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/ProfileServiceTests.cs
@@ -14,7 +14,7 @@ namespace SistemaServicios.Tests.Unit;
 public class ProfileServiceTests
 {
     private readonly Mock<IUserRepository> _mockRepo;
-    private readonly Mock<IWebHostEnvironment> _mockEnv;
+    private readonly Mock<IFileStorage> _mockFileStorage;
     private readonly UserService _service;
     private readonly Mock<IUserLogService> _mockLogService = null!;
     private readonly User _usuario;
@@ -22,13 +22,17 @@ public class ProfileServiceTests
     public ProfileServiceTests()
     {
         _mockRepo = new Mock<IUserRepository>();
-        _mockEnv = new Mock<IWebHostEnvironment>();
-        _mockEnv.Setup(e => e.WebRootPath).Returns(Path.GetTempPath());
+        _mockFileStorage = new Mock<IFileStorage>();
+
         _mockLogService = new Mock<IUserLogService>();
         _mockLogService
             .Setup(l => l.CreateLogAsync(It.IsAny<CreateUserLogDto>()))
             .ReturnsAsync(new UserLogDto());
-        _service = new UserService(_mockRepo.Object, _mockEnv.Object, _mockLogService.Object);
+        _service = new UserService(
+            _mockRepo.Object,
+            _mockFileStorage.Object,
+            _mockLogService.Object
+        );
 
         _usuario = new User
         {
@@ -181,16 +185,26 @@ public class ProfileServiceTests
         var mockFile = new Mock<IFormFile>();
         mockFile.Setup(f => f.ContentType).Returns("image/jpeg");
         mockFile.Setup(f => f.Length).Returns(500_000); // 500 KB
-        mockFile
-            .Setup(f => f.CopyToAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        mockFile.Setup(f => f.OpenReadStream()).Returns(new MemoryStream([1, 2, 3]));
+
+        const string urlAlmacenada = "/api/Files/8a1f0c2e-0000-4000-8000-000000000001";
+        _mockFileStorage
+            .Setup(s =>
+                s.SaveForOwnerAsync(
+                    _usuario.Id,
+                    It.IsAny<Stream>(),
+                    "image/jpeg",
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(urlAlmacenada);
 
         // Act
         var resultado = await _service.UpdateProfileImageAsync(_usuario.Id, mockFile.Object);
 
-        // Assert
+        // Assert: la URL la decide el almacenamiento, no el servicio (issue #125)
         resultado.Should().NotBeNull();
-        resultado!.ProfileImageUrl.Should().Contain($"/uploads/avatars/{_usuario.Id}");
+        resultado!.ProfileImageUrl.Should().Be(urlAlmacenada);
         _mockRepo.Verify(r => r.UpdateUserAsync(It.IsAny<User>()), Times.Once);
     }
 
@@ -239,16 +253,34 @@ public class ProfileServiceTests
         var mockFile = new Mock<IFormFile>();
         mockFile.Setup(f => f.ContentType).Returns("image/png");
         mockFile.Setup(f => f.Length).Returns(300_000); // 300 KB — dentro del límite
-        mockFile
-            .Setup(f => f.CopyToAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        mockFile.Setup(f => f.OpenReadStream()).Returns(new MemoryStream([1, 2, 3]));
+
+        _mockFileStorage
+            .Setup(s =>
+                s.SaveForOwnerAsync(
+                    It.IsAny<Guid>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync("/api/Files/8a1f0c2e-0000-4000-8000-000000000002");
 
         // Act
         var resultado = await _service.UpdateProfileImageAsync(_usuario.Id, mockFile.Object);
 
-        // Assert
+        // Assert: el tipo png llega al almacenamiento; ya no viaja en la extensión
         resultado.Should().NotBeNull();
-        resultado!.ProfileImageUrl.Should().EndWith(".png");
+        _mockFileStorage.Verify(
+            s =>
+                s.SaveForOwnerAsync(
+                    _usuario.Id,
+                    It.IsAny<Stream>(),
+                    "image/png",
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
     }
 
     [Fact]

--- a/backend/SistemaServicios.Tests/Unit/UserRegistrationStatsTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/UserRegistrationStatsTests.cs
@@ -12,20 +12,24 @@ namespace SistemaServicios.Tests.Unit;
 public class UserRegistrationStatsTests
 {
     private readonly Mock<IUserRepository> _mockRepo;
-    private readonly Mock<IWebHostEnvironment> _mockEnv;
+    private readonly Mock<IFileStorage> _mockFileStorage;
     private readonly Mock<IUserLogService> _mockLogService;
     private readonly UserService _service;
 
     public UserRegistrationStatsTests()
     {
         _mockRepo = new Mock<IUserRepository>();
-        _mockEnv = new Mock<IWebHostEnvironment>();
+        _mockFileStorage = new Mock<IFileStorage>();
         _mockLogService = new Mock<IUserLogService>();
         _mockLogService
             .Setup(l => l.CreateLogAsync(It.IsAny<CreateUserLogDto>()))
             .ReturnsAsync(new UserLogDto());
 
-        _service = new UserService(_mockRepo.Object, _mockEnv.Object, _mockLogService.Object);
+        _service = new UserService(
+            _mockRepo.Object,
+            _mockFileStorage.Object,
+            _mockLogService.Object
+        );
     }
 
     [Fact]

--- a/backend/SistemaServicios.Tests/Unit/UserServiceTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/UserServiceTests.cs
@@ -12,7 +12,7 @@ namespace SistemaServicios.Tests.Unit;
 public class UserServiceTests
 {
     private readonly Mock<IUserRepository> _mockRepo;
-    private readonly Mock<IWebHostEnvironment> _mockEnv;
+    private readonly Mock<IFileStorage> _mockFileStorage;
     private readonly UserService _userService;
     private readonly Mock<IUserLogService> _mockLogService;
 
@@ -22,12 +22,16 @@ public class UserServiceTests
     public UserServiceTests()
     {
         _mockRepo = new Mock<IUserRepository>();
-        _mockEnv = new Mock<IWebHostEnvironment>();
+        _mockFileStorage = new Mock<IFileStorage>();
         _mockLogService = new Mock<IUserLogService>();
         _mockLogService
             .Setup(l => l.CreateLogAsync(It.IsAny<CreateUserLogDto>()))
             .ReturnsAsync(new UserLogDto());
-        _userService = new UserService(_mockRepo.Object, _mockEnv.Object, _mockLogService.Object);
+        _userService = new UserService(
+            _mockRepo.Object,
+            _mockFileStorage.Object,
+            _mockLogService.Object
+        );
 
         _usuarioActivo = new User
         {
@@ -642,21 +646,31 @@ public class UserServiceTests
         _ = ex.Message.Should().Contain("2 MB");
     }
 
+    // La forma de la URL dejo de ser responsabilidad de UserService: ahora la decide
+    // el IFileStorage. Estas pruebas verifican la delegacion, no la ruta en disco.
+
     [Fact]
-    public async Task UpdateProfileImageAsyncArchivoJpegValidoGuardaYRetornaDto()
+    public async Task UpdateProfileImageAsyncArchivoValidoGuardaLaUrlQueDevuelveElAlmacenamiento()
     {
         // Arrange
-        var tempDir = Path.GetTempPath();
-        _ = _mockEnv.Setup(e => e.WebRootPath).Returns(tempDir);
+        const string urlDevuelta = "/api/Files/3f2504e0-4f89-11d3-9a0c-0305e82c3301";
         _ = _mockRepo.Setup(r => r.GetByIdAsync(_usuarioActivo.Id)).ReturnsAsync(_usuarioActivo);
         _ = _mockRepo.Setup(r => r.UpdateUserAsync(It.IsAny<User>())).Returns(Task.CompletedTask);
+        _ = _mockFileStorage
+            .Setup(s =>
+                s.SaveForOwnerAsync(
+                    _usuarioActivo.Id,
+                    It.IsAny<Stream>(),
+                    "image/jpeg",
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(urlDevuelta);
 
         var mockFile = new Mock<Microsoft.AspNetCore.Http.IFormFile>();
         _ = mockFile.Setup(f => f.ContentType).Returns("image/jpeg");
         _ = mockFile.Setup(f => f.Length).Returns(1024);
-        _ = mockFile
-            .Setup(f => f.CopyToAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        _ = mockFile.Setup(f => f.OpenReadStream()).Returns(new MemoryStream([1, 2, 3]));
 
         // Act
         var resultado = await _userService.UpdateProfileImageAsync(
@@ -666,33 +680,72 @@ public class UserServiceTests
 
         // Assert
         _ = resultado.Should().NotBeNull();
-        _ = resultado!.ProfileImageUrl.Should().Contain("/uploads/avatars/");
-        _ = resultado.ProfileImageUrl.Should().EndWith(".jpg");
+        _ = resultado!.ProfileImageUrl.Should().Be(urlDevuelta);
     }
 
     [Fact]
-    public async Task UpdateProfileImageAsyncArchivoPngValidoGuardaUrlConExtensionPng()
+    public async Task UpdateProfileImageAsyncPasaElContentTypeRecibidoAlAlmacenamiento()
     {
         // Arrange
-        var tempDir = Path.GetTempPath();
-        _ = _mockEnv.Setup(e => e.WebRootPath).Returns(tempDir);
         _ = _mockRepo.Setup(r => r.GetByIdAsync(_usuarioActivo.Id)).ReturnsAsync(_usuarioActivo);
         _ = _mockRepo.Setup(r => r.UpdateUserAsync(It.IsAny<User>())).Returns(Task.CompletedTask);
+        _ = _mockFileStorage
+            .Setup(s =>
+                s.SaveForOwnerAsync(
+                    It.IsAny<Guid>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync("/api/Files/00000000-0000-0000-0000-000000000001");
 
         var mockFile = new Mock<Microsoft.AspNetCore.Http.IFormFile>();
         _ = mockFile.Setup(f => f.ContentType).Returns("image/png");
         _ = mockFile.Setup(f => f.Length).Returns(512);
-        _ = mockFile
-            .Setup(f => f.CopyToAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        _ = mockFile.Setup(f => f.OpenReadStream()).Returns(new MemoryStream([1, 2, 3]));
 
         // Act
-        var resultado = await _userService.UpdateProfileImageAsync(
-            _usuarioActivo.Id,
-            mockFile.Object
+        _ = await _userService.UpdateProfileImageAsync(_usuarioActivo.Id, mockFile.Object);
+
+        // Assert: el almacenamiento recibe el dueño y el tipo, una sola vez
+        _mockFileStorage.Verify(
+            s =>
+                s.SaveForOwnerAsync(
+                    _usuarioActivo.Id,
+                    It.IsAny<Stream>(),
+                    "image/png",
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task UpdateProfileImageAsyncConTipoNoPermitidoNoTocaElAlmacenamiento()
+    {
+        // Arrange: la validacion debe ocurrir antes de escribir nada
+        _ = _mockRepo.Setup(r => r.GetByIdAsync(_usuarioActivo.Id)).ReturnsAsync(_usuarioActivo);
+
+        var mockFile = new Mock<Microsoft.AspNetCore.Http.IFormFile>();
+        _ = mockFile.Setup(f => f.ContentType).Returns("application/pdf");
+        _ = mockFile.Setup(f => f.Length).Returns(1024);
+
+        // Act
+        _ = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _userService.UpdateProfileImageAsync(_usuarioActivo.Id, mockFile.Object)
         );
 
         // Assert
-        _ = resultado!.ProfileImageUrl.Should().EndWith(".png");
+        _mockFileStorage.Verify(
+            s =>
+                s.SaveForOwnerAsync(
+                    It.IsAny<Guid>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
     }
 }


### PR DESCRIPTION
## 📌 Resumen del Cambio

Los avatares se escribían en `wwwroot/uploads/avatars`, es decir en el disco del contenedor. Eso los ataba a una instancia concreta: **desaparecían en cada despliegue** y, con más de una réplica, la imagen resolvía o no según a qué instancia llegara la petición. Era el último estado local que impedía el escalado horizontal, porque las sesiones ya son stateless gracias al JWT.

Se introduce `IFileStorage` y los archivos pasan a guardarse en PostgreSQL.

**Sobre por qué la base de datos y no S3/R2/B2:** el requisito era no contratar ningún servicio de hosteo. La base ya existe, ya está desplegada y desde #133 tiene respaldo funcionando, así que los avatares pasan a estar respaldados también. Se evaluaron MinIO autoalojado —descartado porque en el plan free de Render no hay disco persistente, lo que reintroduce el mismo problema— y las capas gratuitas de R2/B2/Supabase.

**Lo que perdura del cambio es la abstracción, no el backend elegido.** Migrar a object storage más adelante es añadir una tercera clase y cambiar una línea de registro.

---

## 🔍 Tipo de Cambio realizado

- [x] 🐞 Corrección de error (`fix`)
- [x] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [x] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

**Nuevos**
- `Models/StoredFile.cs`
- `Interfaces/IFileStorage.cs`, `Interfaces/StoredFileContent.cs`
- `Services/DbFileStorage.cs`, `Services/LocalFileStorage.cs`
- `Controllers/FilesController.cs`
- `Migrations/20260813184350_AddStoredFiles.cs`
- `Tests/Unit/DbFileStorageTests.cs`, `Tests/Integration/FilesControllerTests.cs`

**Modificados**
- `Data/AppDbContext.cs` — `DbSet<StoredFile>`, FK `Restrict`, índice por dueño
- `Services/UserService.cs` — depende de `IFileStorage`, ya no de `IWebHostEnvironment`
- `Extensions/ApplicationServiceExtensions.cs` — registro según `FILE_STORAGE`
- `.env.example` — documenta `FILE_STORAGE`
- `Tests/Unit/{UserServiceTests,ProfileServiceTests,UserRegistrationStatsTests}.cs`, `Tests/Integration/ProfileControllerTests.cs`

---

## 🧪 ¿Cómo Probarlo?

```bash
dotnet run --project backend/SistemaServicios.API
```

En `http://localhost:5000/swagger`, con sesión iniciada: `POST /api/Profile/foto` con una imagen JPG o PNG de menos de 2 MB.

Qué debería verse:

1. La respuesta trae `profileImageUrl` con la forma `/api/Files/{guid}`, ya no `/uploads/avatars/…`.
2. Abrir `http://localhost:5000/api/Files/{guid}` en el navegador **sin sesión** muestra la imagen.
3. Subir otra foto genera un guid distinto, y la fila anterior de ese usuario desaparece de `StoredFiles`.
4. Reiniciar la aplicación y recargar: la imagen sigue ahí. Antes se perdía.

Para volver temporalmente al comportamiento en disco, `FILE_STORAGE=local`.

```bash
cd backend && dotnet test
```

---

## ✅ Checklist

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [x] Se han actualizado o agregado pruebas
- [x] La documentación se actualizó si fue necesario
- [x] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Closes #125

### Decisiones que no se deducen del diff

**Tabla propia y no columna en `Users`.** Si los bytes vivieran en `Users`, cualquier consulta de usuarios arrastraría las imágenes salvo que se proyecte explícitamente — y la auditoría ya señala que faltan proyecciones. Con tabla separada eso no puede ocurrir por descuido.

**`OwnerUserId` con índice, en vez de deducir el identificador desde la URL.** Al subir un avatar se borran las filas previas de ese usuario. Elimina de raíz el huérfano que quedaba al cambiar de JPG a PNG, y hay una prueba que verifica que no toca los archivos de otros usuarios.

**Caché inmutable de un año en el endpoint.** Es seguro precisamente porque el identificador cambia en cada subida: el cache-busting sale gratis y no hay que invalidar nada. Compensa en parte no tener CDN.

**El endpoint es anónimo a propósito**, porque los avatares se muestran en el catálogo público, que se consulta sin iniciar sesión.

**Corrección respecto al planteamiento original del issue.** El borrador afirmaba que había que añadir validación de tipo y tamaño, y que cada cambio de foto dejaba basura en disco. Ambas cosas eran inexactas: `UserService` ya validaba MIME y los 2 MB, y el nombre `{userId}{ext}` sobrescribía, de modo que el único huérfano posible era uno por usuario al cambiar de extensión.

### Cambio de comportamiento

`ProfileImageUrl` pasa de `/uploads/avatars/{id}.jpg` a `/api/Files/{guid}`. **Sigue siendo relativa**, así que el frontend, que concatena la URL base de la API, no necesita ningún cambio.

**Seis pruebas existentes se actualizaron, ninguna se eliminó.** Afirmaban la forma de la ruta en disco, que ya no es responsabilidad de `UserService`. Las de integración ahora verifican algo más fuerte que antes: que la imagen se recupera de verdad por su URL, sin token, y con el `Content-Type` correcto.

### Migración de datos

**Los avatares anteriores con URL `/uploads/…` no se migran.** En producción ya no sobrevive ninguno —es precisamente el defecto que se corrige— y en local siguen resolviendo porque `UseStaticFiles` se deja intacto. No hay regresión.

La migración EF crea `StoredFiles` y se aplicará sola en el próximo despliegue vía `efbundle`.

### Límites conocidos

- Los avatares entran en el `pg_dump`, lo que engorda el respaldo. Con el tope de 2 MB y el volumen actual es irrelevante, pero conviene saberlo.
- El plan free de Render da 1 GB de base: con 2 MB por avatar son del orden de 500 en el peor caso. Suficiente para un piloto, insuficiente para escala — y ahí es donde la abstracción paga sola.
- No hay CDN: las imágenes se sirven desde la API, mitigado con la caché inmutable.

### Relación con otros issues

Junto con #133, ya mergeado, y #126, este cierra el bloque que impedía pasar de escalado vertical a horizontal. Queda #128 (reverse proxy) como complemento operativo.

### Verificación

Suite completa: **242 pruebas, 0 fallos** (eran 231). CSharpier y los analizadores, limpios con `TreatWarningsAsErrors`.
