### PR TITLE
perf(backend): mueve el respaldo y el envío de correo a segundo plano

### DIFF
--- a/backend/SistemaServicios.API/Controllers/AdminController.cs
+++ b/backend/SistemaServicios.API/Controllers/AdminController.cs
@@ -11,35 +11,72 @@ namespace SistemaServicios.API.Controllers;
 public partial class AdminController : ControllerBase
 {
     private readonly IBackupService _backupService;
+    private readonly IBackgroundTaskDispatcher _queue;
+    private readonly IBackupJobTracker _jobTracker;
     private readonly ILogger<AdminController> _logger;
 
-    public AdminController(IBackupService backupService, ILogger<AdminController> logger)
+    public AdminController(
+        IBackupService backupService,
+        IBackgroundTaskDispatcher queue,
+        IBackupJobTracker jobTracker,
+        ILogger<AdminController> logger
+    )
     {
         _backupService = backupService;
+        _queue = queue;
+        _jobTracker = jobTracker;
         _logger = logger;
     }
 
     /// <summary>
-    /// Genera un respaldo de la base de datos. Requiere rol Admin.
+    /// Encola la generación de un respaldo y responde de inmediato. Requiere rol Admin.
     /// </summary>
     [HttpPost("backup")]
     public async Task<IActionResult> CreateBackup()
     {
-        try
+        var (job, created) = _jobTracker.StartOrGetActive();
+
+        if (!created)
         {
-            var result = await _backupService.GenerateBackupAsync();
-            return StatusCode(201, result);
+            // Ya hay uno en curso: se devuelve ese en lugar de lanzar un segundo
+            // pg_dump en paralelo contra la misma base.
+            return Accepted(job);
         }
-        catch (InvalidOperationException ex)
-        {
-            // El detalle va al log, no a la respuesta: ex.Message arrastra rutas
-            // internas del contenedor y la salida cruda de pg_dump.
-            LogFalloDeRespaldo(ex);
-            return StatusCode(
-                500,
-                new { message = "No se pudo generar el respaldo de la base de datos." }
-            );
-        }
+
+        await _queue.EnqueueAsync(
+            async (serviceProvider, _) =>
+            {
+                var tracker = serviceProvider.GetRequiredService<IBackupJobTracker>();
+                var backups = serviceProvider.GetRequiredService<IBackupService>();
+
+                tracker.MarkRunning(job.Id);
+
+                try
+                {
+                    var result = await backups.GenerateBackupAsync();
+                    tracker.MarkCompleted(job.Id, result.FileName, result.FileSizeBytes);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    // El detalle interno queda en el estado del trabajo y en el log,
+                    // no en una respuesta HTTP.
+                    tracker.MarkFailed(job.Id, "No se pudo generar el respaldo.");
+                    LogFalloDeRespaldo(ex);
+                }
+            }
+        );
+
+        return Accepted(job);
+    }
+
+    /// <summary>
+    /// Consulta el estado de un trabajo de respaldo. Requiere rol Admin.
+    /// </summary>
+    [HttpGet("backup/jobs/{id:guid}")]
+    public IActionResult GetBackupJob(Guid id)
+    {
+        var job = _jobTracker.Find(id);
+        return job is null ? NotFound(new { message = "El trabajo no existe." }) : Ok(job);
     }
 
     /// <summary>

--- a/backend/SistemaServicios.API/DTOs/Admin/BackupJobDto.cs
+++ b/backend/SistemaServicios.API/DTOs/Admin/BackupJobDto.cs
@@ -1,0 +1,32 @@
+namespace SistemaServicios.API.DTOs.Admin;
+
+public enum BackupJobStatus
+{
+    Pendiente = 0,
+    EnProceso = 1,
+    Completado = 2,
+    Fallido = 3,
+}
+
+/// <summary>
+/// Estado de un trabajo de respaldo. Sustituye a la espera síncrona: el cliente recibe
+/// el identificador y consulta el avance en lugar de mantener la petición abierta.
+/// </summary>
+public class BackupJobDto
+{
+    public Guid Id { get; set; }
+
+    public BackupJobStatus Status { get; set; }
+
+    /// <summary>Nombre del archivo generado. Solo con estado Completado.</summary>
+    public string? FileName { get; set; }
+
+    public long? FileSizeBytes { get; set; }
+
+    /// <summary>Motivo del fallo, apto para mostrarse al administrador.</summary>
+    public string? Error { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public DateTime? FinishedAt { get; set; }
+}

--- a/backend/SistemaServicios.API/Data/AppDbContext.cs
+++ b/backend/SistemaServicios.API/Data/AppDbContext.cs
@@ -76,6 +76,7 @@ public class AppDbContext : DbContext
         // Índice compuesto: acelera el listado paginado de solicitudes por profesional
         // ordenado por fecha, evitando table scans a medida que crece el volumen
         modelBuilder.Entity<Request>().HasIndex(r => new { r.ProfessionalId, r.RequestDate });
+
         // Único: evita condición de carrera en el registro (antes solo se validaba en la app con EmailExistsAsync)
         modelBuilder.Entity<User>().HasIndex(u => u.Email).IsUnique();
 
@@ -91,6 +92,7 @@ public class AppDbContext : DbContext
         // revisarse: HasFilter ya no aplicaría tal cual y habría que evaluar qué subconjunto
         // de estados sigue siendo el "camino caliente" de lectura.
         modelBuilder.Entity<User>().HasIndex(u => u.Status).HasFilter("\"Status\" = true");
+
         // StoredFile: mismo criterio que el resto, sin borrado en cascada.
         // El borrado de usuarios es lógico, así que sus archivos se conservan.
         modelBuilder
@@ -103,6 +105,5 @@ public class AppDbContext : DbContext
         // El reemplazo de avatar busca por dueño: sin índice sería un scan completo
         // de una tabla que guarda binarios.
         modelBuilder.Entity<StoredFile>().HasIndex(f => f.OwnerUserId);
-
     }
 }

--- a/backend/SistemaServicios.API/Extensions/ApplicationServiceExtensions.cs
+++ b/backend/SistemaServicios.API/Extensions/ApplicationServiceExtensions.cs
@@ -98,7 +98,18 @@ public static class ApplicationServiceExtensions
         services.AddScoped<IRatingService, RatingService>();
         services.AddScoped<IServiceRequestRepository, ServiceRequestRepository>();
         services.AddScoped<IServiceRequestService, ServiceRequestService>();
-        services.AddScoped<IEmailService, EmailService>();
+
+        // Cola de trabajos en segundo plano: saca pg_dump y SMTP del ciclo
+        // petición-respuesta. Singleton porque la cola y el estado de los trabajos
+        // se comparten entre peticiones y con el consumidor.
+        services.AddSingleton<IBackgroundTaskDispatcher>(_ => new BackgroundTaskDispatcher());
+        services.AddSingleton<IBackupJobTracker, BackupJobTracker>();
+        services.AddHostedService<QueuedHostedService>();
+
+        // EmailService concreto es el transporte real; QueuedEmailService lo envuelve
+        // para encolarlo. Quien depende de IEmailService no se entera del cambio.
+        services.AddScoped<EmailService>();
+        services.AddScoped<IEmailService, QueuedEmailService>();
         services.AddScoped<IUserLogRepository, UserLogRepository>();
         services.AddScoped<IUserLogService, UserLogService>();
         services.AddScoped<ICategoryRepository, CategoryRepository>();

--- a/backend/SistemaServicios.API/Interfaces/IBackgroundTaskDispatcher.cs
+++ b/backend/SistemaServicios.API/Interfaces/IBackgroundTaskDispatcher.cs
@@ -1,0 +1,20 @@
+namespace SistemaServicios.API.Interfaces;
+
+/// <summary>
+/// Cola de trabajos en segundo plano. Existe para sacar del ciclo petición-respuesta
+/// las operaciones de duración impredecible (pg_dump, SMTP) que hoy bloquean al usuario.
+/// </summary>
+public interface IBackgroundTaskDispatcher
+{
+    /// <summary>
+    /// Encola un trabajo. Recibe un <see cref="IServiceProvider"/> propio porque se
+    /// ejecuta fuera del ámbito de la petición HTTP y no puede reutilizar sus
+    /// dependencias con ámbito.
+    /// </summary>
+    public ValueTask EnqueueAsync(Func<IServiceProvider, CancellationToken, ValueTask> workItem);
+
+    /// <summary>Espera hasta que haya un trabajo disponible y lo devuelve.</summary>
+    public ValueTask<Func<IServiceProvider, CancellationToken, ValueTask>> DequeueAsync(
+        CancellationToken cancellationToken
+    );
+}

--- a/backend/SistemaServicios.API/Interfaces/IBackupJobTracker.cs
+++ b/backend/SistemaServicios.API/Interfaces/IBackupJobTracker.cs
@@ -1,0 +1,31 @@
+using SistemaServicios.API.DTOs.Admin;
+
+namespace SistemaServicios.API.Interfaces;
+
+/// <summary>
+/// Registro del estado de los trabajos de respaldo. Es singleton y vive en memoria:
+/// el estado se pierde al reiniciar, lo que es aceptable porque el respaldo en sí
+/// queda en disco y se lista con el endpoint de respaldos.
+/// </summary>
+public interface IBackupJobTracker
+{
+    /// <summary>
+    /// Devuelve el trabajo activo si ya hay uno, o crea uno nuevo. El segundo elemento
+    /// indica si se creó: evita que dos peticiones lancen dos pg_dump concurrentes.
+    /// </summary>
+    public (BackupJobDto job, bool created) StartOrGetActive();
+
+    public BackupJobDto? Find(Guid id);
+
+    public void MarkRunning(Guid id);
+
+    public void MarkCompleted(Guid id, string fileName, long fileSizeBytes);
+
+    public void MarkFailed(Guid id, string reason);
+
+    /// <summary>
+    /// Marca como fallidos los trabajos sin terminar. Se llama al apagar el proceso
+    /// para que ninguno quede en EnProceso para siempre.
+    /// </summary>
+    public void FailActiveJobs(string reason);
+}

--- a/backend/SistemaServicios.API/Services/AuthService.cs
+++ b/backend/SistemaServicios.API/Services/AuthService.cs
@@ -68,15 +68,17 @@ public class AuthService : IAuthService
 
     public async Task ForgotPasswordAsync(ForgotPasswordRequestDto dto)
     {
-        var user =
-            await _userRepo.GetByEmailAsync(dto.Email)
-            ?? throw new InvalidOperationException(
-                "Si el correo está registrado, recibirás tu nueva contraseña en breve."
-            );
+        var user = await _userRepo.GetByEmailAsync(dto.Email);
 
-        if (!user.Status)
+        // Cuenta inexistente y cuenta desactivada se tratan igual y en silencio.
+        // Antes, la desactivada respondía "La cuenta está desactivada.", lo que
+        // confirmaba que el correo estaba registrado: enumeración de cuentas.
+        if (user is null || !user.Status)
         {
-            throw new InvalidOperationException("La cuenta está desactivada.");
+            // Hash de descarte: sin él, el camino sin cuenta terminaría al instante y
+            // la diferencia de tiempo delataría lo que el mensaje ya no delata.
+            _ = BCrypt.Net.BCrypt.HashPassword(GenerateSecurePassword(), workFactor: 10);
+            return;
         }
 
         var newPassword = GenerateSecurePassword();
@@ -84,6 +86,7 @@ public class AuthService : IAuthService
         user.PasswordHash = BCrypt.Net.BCrypt.HashPassword(newPassword, workFactor: 10);
         await _userRepo.UpdateUserAsync(user);
 
+        // Encolado: retorna sin esperar al servidor SMTP.
         await _emailService.SendPasswordResetEmailAsync(user.Email, newPassword);
     }
 

--- a/backend/SistemaServicios.API/Services/BackgroundTaskDispatcher.cs
+++ b/backend/SistemaServicios.API/Services/BackgroundTaskDispatcher.cs
@@ -1,0 +1,43 @@
+using System.Threading.Channels;
+using SistemaServicios.API.Interfaces;
+
+namespace SistemaServicios.API.Services;
+
+/// <summary>
+/// Cola en memoria sobre <see cref="Channel{T}"/>. No añade infraestructura externa,
+/// con la contrapartida de que los trabajos pendientes se pierden si el proceso muere.
+/// Es aceptable para respaldos y correos de recuperación, que el usuario puede repetir.
+/// </summary>
+public class BackgroundTaskDispatcher : IBackgroundTaskDispatcher
+{
+    private readonly Channel<Func<IServiceProvider, CancellationToken, ValueTask>> _queue;
+
+    public BackgroundTaskDispatcher(int capacity = 100)
+    {
+        // Espera en vez de descartar cuando la cola se llena: perder un respaldo o un
+        // correo en silencio sería peor que tardar un momento en aceptarlo.
+        var options = new BoundedChannelOptions(capacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+        };
+
+        _queue = Channel.CreateBounded<Func<IServiceProvider, CancellationToken, ValueTask>>(
+            options
+        );
+    }
+
+    public async ValueTask EnqueueAsync(
+        Func<IServiceProvider, CancellationToken, ValueTask> workItem
+    )
+    {
+        ArgumentNullException.ThrowIfNull(workItem);
+        await _queue.Writer.WriteAsync(workItem);
+    }
+
+    public async ValueTask<Func<IServiceProvider, CancellationToken, ValueTask>> DequeueAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        return await _queue.Reader.ReadAsync(cancellationToken);
+    }
+}

--- a/backend/SistemaServicios.API/Services/BackupJobTracker.cs
+++ b/backend/SistemaServicios.API/Services/BackupJobTracker.cs
@@ -1,0 +1,87 @@
+using System.Collections.Concurrent;
+using SistemaServicios.API.DTOs.Admin;
+using SistemaServicios.API.Interfaces;
+
+namespace SistemaServicios.API.Services;
+
+public class BackupJobTracker : IBackupJobTracker
+{
+    private readonly ConcurrentDictionary<Guid, BackupJobDto> _jobs = new();
+
+    // La comprobación de "hay uno activo" y la creación deben ser atómicas entre sí:
+    // sin el candado, dos peticiones simultáneas crearían dos trabajos.
+    private readonly Lock _gate = new();
+
+    public (BackupJobDto job, bool created) StartOrGetActive()
+    {
+        lock (_gate)
+        {
+            var activo = _jobs.Values.FirstOrDefault(j =>
+                j.Status is BackupJobStatus.Pendiente or BackupJobStatus.EnProceso
+            );
+
+            if (activo is not null)
+            {
+                return (activo, false);
+            }
+
+            var nuevo = new BackupJobDto
+            {
+                Id = Guid.NewGuid(),
+                Status = BackupJobStatus.Pendiente,
+                CreatedAt = DateTime.UtcNow,
+            };
+
+            _jobs[nuevo.Id] = nuevo;
+            return (nuevo, true);
+        }
+    }
+
+    public BackupJobDto? Find(Guid id) => _jobs.TryGetValue(id, out var job) ? job : null;
+
+    public void MarkRunning(Guid id)
+    {
+        if (_jobs.TryGetValue(id, out var job))
+        {
+            job.Status = BackupJobStatus.EnProceso;
+        }
+    }
+
+    public void MarkCompleted(Guid id, string fileName, long fileSizeBytes)
+    {
+        if (_jobs.TryGetValue(id, out var job))
+        {
+            job.Status = BackupJobStatus.Completado;
+            job.FileName = fileName;
+            job.FileSizeBytes = fileSizeBytes;
+            job.FinishedAt = DateTime.UtcNow;
+        }
+    }
+
+    public void MarkFailed(Guid id, string reason)
+    {
+        if (_jobs.TryGetValue(id, out var job))
+        {
+            job.Status = BackupJobStatus.Fallido;
+            job.Error = reason;
+            job.FinishedAt = DateTime.UtcNow;
+        }
+    }
+
+    public void FailActiveJobs(string reason)
+    {
+        lock (_gate)
+        {
+            foreach (
+                var job in _jobs.Values.Where(j =>
+                    j.Status is BackupJobStatus.Pendiente or BackupJobStatus.EnProceso
+                )
+            )
+            {
+                job.Status = BackupJobStatus.Fallido;
+                job.Error = reason;
+                job.FinishedAt = DateTime.UtcNow;
+            }
+        }
+    }
+}

--- a/backend/SistemaServicios.API/Services/EmailService.cs
+++ b/backend/SistemaServicios.API/Services/EmailService.cs
@@ -13,14 +13,24 @@ public class EmailService : IEmailService
 
     public EmailService(IConfiguration config, ISmtpClientWrapper? smtpClient = null)
     {
-        // Usamos valores por defecto si no encuentra la configuración en el entorno de pruebas
-        var host = config["SmtpSettings:Host"] ?? "smtp.test.com";
+        // Falla al arrancar si falta configuración, en lugar de caer en valores de
+        // relleno. Con valores por defecto, un SMTP mal configurado en producción no
+        // da ningún síntoma: los correos simplemente no llegan. El entorno de pruebas
+        // aporta su propia configuración (CustomWebApplicationFactory), que es donde
+        // corresponde resolverlo.
+        var host =
+            config["SmtpSettings:Host"]
+            ?? throw new InvalidOperationException("SMTP_HOST no configurado.");
         var port = int.Parse(
             config["SmtpSettings:Port"] ?? "587",
             System.Globalization.CultureInfo.InvariantCulture
         );
-        var user = config["SmtpSettings:User"] ?? "test@test.com";
-        var password = config["SmtpSettings:Password"] ?? "password";
+        var user =
+            config["SmtpSettings:User"]
+            ?? throw new InvalidOperationException("SMTP_USER no configurado.");
+        var password =
+            config["SmtpSettings:Password"]
+            ?? throw new InvalidOperationException("SMTP_PASSWORD no configurado.");
 
         _from = config["SmtpSettings:From"] ?? user;
         _smtpClient = smtpClient ?? new SmtpClientWrapper(host, port, user, password);

--- a/backend/SistemaServicios.API/Services/QueuedEmailService.cs
+++ b/backend/SistemaServicios.API/Services/QueuedEmailService.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.DependencyInjection;
+using SistemaServicios.API.Interfaces;
+
+namespace SistemaServicios.API.Services;
+
+/// <summary>
+/// Envuelve el envío real y lo saca de la petición HTTP. El usuario deja de esperar a
+/// que responda el servidor SMTP, y de paso el tiempo de respuesta deja de delatar si
+/// la cuenta existe: antes, encontrarla implicaba esperar al envío completo.
+/// </summary>
+public partial class QueuedEmailService : IEmailService
+{
+    private const int MaxIntentos = 3;
+
+    private readonly IBackgroundTaskDispatcher _queue;
+    private readonly ILogger<QueuedEmailService> _logger;
+    private readonly TimeSpan _esperaBase;
+
+    /// <param name="esperaBase">
+    /// Base del backoff exponencial. Es inyectable para que las pruebas puedan
+    /// ejercitar los reintentos sin esperar segundos reales.
+    /// </param>
+    public QueuedEmailService(
+        IBackgroundTaskDispatcher queue,
+        ILogger<QueuedEmailService> logger,
+        TimeSpan? esperaBase = null
+    )
+    {
+        _queue = queue;
+        _logger = logger;
+        _esperaBase = esperaBase ?? TimeSpan.FromSeconds(1);
+    }
+
+    public async Task SendPasswordResetEmailAsync(string toEmail, string newPassword)
+    {
+        await _queue.EnqueueAsync(
+            async (serviceProvider, cancellationToken) =>
+            {
+                var sender = serviceProvider.GetRequiredService<EmailService>();
+
+                for (var intento = 1; intento <= MaxIntentos; intento++)
+                {
+                    try
+                    {
+                        await sender.SendPasswordResetEmailAsync(toEmail, newPassword);
+                        return;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (intento == MaxIntentos)
+                        {
+                            // Agotados los intentos, el fallo se registra pero no se
+                            // propaga: al usuario nunca debe llegarle, porque saber que su
+                            // correo no salió revelaría que la cuenta existe.
+                            LogFalloDefinitivo(MaxIntentos, ex);
+                            return;
+                        }
+
+                        // Fallo transitorio del proveedor: se reintenta con espera creciente.
+                        LogReintento(intento, ex);
+                        var espera = _esperaBase * Math.Pow(2, intento);
+                        await Task.Delay(espera, cancellationToken);
+                    }
+                }
+            }
+        );
+    }
+
+    [LoggerMessage(
+        EventId = 2100,
+        Level = LogLevel.Warning,
+        Message = "Falló el envío de correo en el intento {Intento}; se reintentará"
+    )]
+    private partial void LogReintento(int intento, Exception exception);
+
+    [LoggerMessage(
+        EventId = 2101,
+        Level = LogLevel.Error,
+        Message = "No se pudo enviar el correo de recuperación tras {Intentos} intentos"
+    )]
+    private partial void LogFalloDefinitivo(int intentos, Exception exception);
+}

--- a/backend/SistemaServicios.API/Services/QueuedHostedService.cs
+++ b/backend/SistemaServicios.API/Services/QueuedHostedService.cs
@@ -1,0 +1,77 @@
+using SistemaServicios.API.Interfaces;
+
+namespace SistemaServicios.API.Services;
+
+/// <summary>
+/// Consume la cola de trabajos en segundo plano. Cada trabajo se ejecuta en su propio
+/// ámbito de dependencias, porque el de la petición HTTP ya no existe cuando corre.
+/// </summary>
+public partial class QueuedHostedService : BackgroundService
+{
+    private readonly IBackgroundTaskDispatcher _queue;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IBackupJobTracker _jobTracker;
+    private readonly ILogger<QueuedHostedService> _logger;
+
+    public QueuedHostedService(
+        IBackgroundTaskDispatcher queue,
+        IServiceScopeFactory scopeFactory,
+        IBackupJobTracker jobTracker,
+        ILogger<QueuedHostedService> logger
+    )
+    {
+        _queue = queue;
+        _scopeFactory = scopeFactory;
+        _jobTracker = jobTracker;
+        _logger = logger;
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Sin esto, un respaldo interrumpido por el apagado quedaría en EnProceso
+        // indefinidamente y el administrador no podría lanzar otro.
+        _jobTracker.FailActiveJobs("El servicio se detuvo antes de completar el trabajo.");
+        await base.StopAsync(cancellationToken);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            Func<IServiceProvider, CancellationToken, ValueTask> workItem;
+
+            try
+            {
+                workItem = await _queue.DequeueAsync(stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Apagado normal del proceso.
+                break;
+            }
+
+            using var scope = _scopeFactory.CreateScope();
+
+            try
+            {
+                await workItem(scope.ServiceProvider, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // Un trabajo que falla no debe tumbar al consumidor: se registra y se sigue.
+                LogFalloDeTrabajo(ex);
+            }
+        }
+    }
+
+    [LoggerMessage(
+        EventId = 2000,
+        Level = LogLevel.Error,
+        Message = "Falló un trabajo en segundo plano"
+    )]
+    private partial void LogFalloDeTrabajo(Exception exception);
+}

--- a/backend/SistemaServicios.Tests/Integration/AdminControllerTests.cs
+++ b/backend/SistemaServicios.Tests/Integration/AdminControllerTests.cs
@@ -164,48 +164,47 @@ public class AdminControllerTests : IClassFixture<AdminWebApplicationFactory>
         _ = response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
+    /// <summary>
+    /// Espera a que el trabajo llegue a un estado final. El respaldo corre en segundo
+    /// plano, así que consultar el estado justo tras aceptar la petición es una carrera.
+    /// </summary>
+    private async Task<BackupJobDto> EsperarEstadoFinal(Guid jobId, string token)
+    {
+        for (var intento = 0; intento < 50; intento++)
+        {
+            var res = await _client.SendAsync(
+                BuildRequest("GET", $"/api/admin/backup/jobs/{jobId}", token)
+            );
+            var job = await res.Content.ReadFromJsonAsync<BackupJobDto>();
+
+            if (job!.Status is BackupJobStatus.Completado or BackupJobStatus.Fallido)
+            {
+                return job;
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException("El trabajo de respaldo no terminó a tiempo.");
+    }
+
     // ─────────────────────────────────────────────────────────────
     // POST /api/admin/backup — flujo de negocio (con token Admin)
     // ─────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task CreateBackupConTokenDeAdminBackupExitosoRetorna201()
+    public async Task CreateBackupConTokenDeAdminRetorna202YNoEsperaAlVolcado()
     {
-        // Arrange
-        var backupEsperado = new BackupResponseDto
-        {
-            FileName = "backup_20260226_1200.sql",
-            CreatedAt = new DateTime(2026, 2, 26, 12, 0, 0, DateTimeKind.Utc),
-            FileSizeBytes = 20480,
-        };
-
-        _ = _backupMock.Setup(s => s.GenerateBackupAsync()).ReturnsAsync(backupEsperado);
-
-        var token = GenerarToken(UserRole.Admin);
-        var request = BuildRequest("POST", "/api/admin/backup", token);
-
-        // Act
-        var response = await _client.SendAsync(request);
-
-        // Assert
-        _ = response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var body = await response.Content.ReadFromJsonAsync<BackupResponseDto>();
-        _ = body!.FileName.Should().Be("backup_20260226_1200.sql");
-        _ = body.FileSizeBytes.Should().Be(20480);
-    }
-
-    [Fact]
-    public async Task CreateBackupConTokenDeAdminBackupExitosoRetornaJsonConFileName()
-    {
-        // Arrange
+        // Arrange: el respaldo pasó a segundo plano (issue #126). Antes esta prueba
+        // esperaba 201 con el archivo ya generado.
         _ = _backupMock
             .Setup(s => s.GenerateBackupAsync())
             .ReturnsAsync(
                 new BackupResponseDto
                 {
-                    FileName = "backup_20260226_1430.sql",
-                    CreatedAt = DateTime.UtcNow,
-                    FileSizeBytes = 1024,
+                    FileName = "backup_20260226_1200.sql",
+                    CreatedAt = new DateTime(2026, 2, 26, 12, 0, 0, DateTimeKind.Utc),
+                    FileSizeBytes = 20480,
                 }
             );
 
@@ -214,19 +213,25 @@ public class AdminControllerTests : IClassFixture<AdminWebApplicationFactory>
 
         // Act
         var response = await _client.SendAsync(request);
-        var contenido = await response.Content.ReadAsStringAsync();
 
-        // Assert
-        _ = response.StatusCode.Should().Be(HttpStatusCode.Created);
-        _ = contenido.Should().Contain("backup_20260226_1430.sql");
-        _ = contenido.Should().Contain("fileSizeBytes");
-        _ = contenido.Should().Contain("createdAt");
+        // Assert: la petición se acepta de inmediato
+        _ = response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var job = await response.Content.ReadFromJsonAsync<BackupJobDto>();
+        _ = job!.Id.Should().NotBeEmpty();
+
+        // Y el trabajo se completa después, ya fuera de la petición: esto verifica
+        // la tubería entera, incluido el consumidor en segundo plano.
+        var final = await EsperarEstadoFinal(job.Id, token);
+        _ = final.Status.Should().Be(BackupJobStatus.Completado);
+        _ = final.FileName.Should().Be("backup_20260226_1200.sql");
+        _ = final.FileSizeBytes.Should().Be(20480);
     }
 
     [Fact]
-    public async Task CreateBackupConTokenDeAdminBackupFallaRetorna500()
+    public async Task CreateBackupConTokenDeAdminAceptaAunqueElVolcadoVayaAFallar()
     {
-        // Arrange: el servicio lanza una excepción de operación inválida (pg_dump falló)
+        // Arrange: el fallo ocurre en segundo plano, así que la petición se acepta igual.
+        // Antes devolvía 500 porque esperaba a pg_dump dentro de la petición.
         _ = _backupMock
             .Setup(s => s.GenerateBackupAsync())
             .ThrowsAsync(
@@ -238,35 +243,89 @@ public class AdminControllerTests : IClassFixture<AdminWebApplicationFactory>
 
         // Act
         var response = await _client.SendAsync(request);
-
-        // Assert
-        _ = response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
         var contenido = await response.Content.ReadAsStringAsync();
 
-        // El detalle interno no viaja al cliente (issue #133): esta aserción estaba
-        // invertida antes, comprobando que "pg_dump falló" SÍ aparecía en la respuesta.
+        // Assert: nunca 500, y el detalle interno tampoco viaja al cliente
+        _ = response.StatusCode.Should().Be(HttpStatusCode.Accepted);
         _ = contenido.Should().NotContain("pg_dump");
-        _ = contenido.Should().Contain("No se pudo generar el respaldo");
+
+        // El fallo queda registrado en el estado del trabajo, sin filtrar el detalle
+        var job = await response.Content.ReadFromJsonAsync<BackupJobDto>();
+        var final = await EsperarEstadoFinal(job!.Id, token);
+        _ = final.Status.Should().Be(BackupJobStatus.Fallido);
+        _ = final.Error.Should().NotContain("pg_dump");
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // GET /api/admin/backup/jobs/{id} — estado del trabajo
+    // ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetBackupJobSinTokenRetorna401()
+    {
+        // Arrange
+        var request = BuildRequest("GET", $"/api/admin/backup/jobs/{Guid.NewGuid()}");
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        _ = response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     [Fact]
-    public async Task CreateBackupConTokenDeAdminLlamaAlServicioUnaVez()
+    public async Task GetBackupJobConTokenDeClientRetorna403()
     {
-        // Arrange: el mock es compartido por IClassFixture; se limpian las invocaciones
-        // previas para que Times.Once solo cuente la llamada de este test.
-        _backupMock.Invocations.Clear();
-        _ = _backupMock
-            .Setup(s => s.GenerateBackupAsync())
-            .ReturnsAsync(new BackupResponseDto { FileName = "backup.sql" });
-
-        var token = GenerarToken(UserRole.Admin);
-        var request = BuildRequest("POST", "/api/admin/backup", token);
+        // Arrange
+        var token = GenerarToken(UserRole.Client);
+        var request = BuildRequest("GET", $"/api/admin/backup/jobs/{Guid.NewGuid()}", token);
 
         // Act
-        _ = await _client.SendAsync(request);
+        var response = await _client.SendAsync(request);
 
-        // Assert: el pipeline no genera llamadas duplicadas al servicio
-        _backupMock.Verify(s => s.GenerateBackupAsync(), Times.Once);
+        // Assert
+        _ = response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetBackupJobConIdInexistenteRetorna404()
+    {
+        // Arrange
+        var token = GenerarToken(UserRole.Admin);
+        var request = BuildRequest("GET", $"/api/admin/backup/jobs/{Guid.NewGuid()}", token);
+
+        // Act
+        var response = await _client.SendAsync(request);
+
+        // Assert
+        _ = response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetBackupJobDelTrabajoRecienCreadoRetorna200()
+    {
+        // Arrange
+        _ = _backupMock
+            .Setup(s => s.GenerateBackupAsync())
+            .ReturnsAsync(new BackupResponseDto { FileName = "backup_20260226_1200.sql" });
+
+        var token = GenerarToken(UserRole.Admin);
+        var creado = await _client.SendAsync(BuildRequest("POST", "/api/admin/backup", token));
+        var job = await creado.Content.ReadFromJsonAsync<BackupJobDto>();
+
+        // Act
+        var response = await _client.SendAsync(
+            BuildRequest("GET", $"/api/admin/backup/jobs/{job!.Id}", token)
+        );
+
+        // Assert
+        _ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var consultado = await response.Content.ReadFromJsonAsync<BackupJobDto>();
+        _ = consultado!.Id.Should().Be(job.Id);
+
+        // Se drena el trabajo para no dejarlo activo y afectar a otras pruebas:
+        // el guardia de concurrencia devolvería este mismo trabajo.
+        _ = await EsperarEstadoFinal(job.Id, token);
     }
 
     // ─────────────────────────────────────────────────────────────

--- a/backend/SistemaServicios.Tests/Integration/CustomWebApplicationFactory.cs
+++ b/backend/SistemaServicios.Tests/Integration/CustomWebApplicationFactory.cs
@@ -39,6 +39,14 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
         Environment.SetEnvironmentVariable("DB_PASSWORD", "fake");
         // CORS: origen de prueba que CorsTests utilizará para verificar la política FrontendPolicy.
         Environment.SetEnvironmentVariable("ALLOWED_ORIGINS", "http://localhost:3000");
+        // SMTP: el entorno de pruebas aporta la configuración, igual que con JWT y BD.
+        // Es aquí donde debe resolverse, y no haciendo que EmailService invente valores
+        // por defecto: eso ocultaría una mala configuración en producción.
+        Environment.SetEnvironmentVariable("SMTP_HOST", "smtp.test.com");
+        Environment.SetEnvironmentVariable("SMTP_PORT", "587");
+        Environment.SetEnvironmentVariable("SMTP_USER", "test@test.com");
+        Environment.SetEnvironmentVariable("SMTP_PASSWORD", "password");
+        Environment.SetEnvironmentVariable("SMTP_FROM", "noreply@test.com");
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/backend/SistemaServicios.Tests/Unit/AdminControllerTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/AdminControllerTests.cs
@@ -5,35 +5,128 @@ using Moq;
 using SistemaServicios.API.Controllers;
 using SistemaServicios.API.DTOs.Admin;
 using SistemaServicios.API.Interfaces;
+using SistemaServicios.API.Services;
 using Xunit;
 
 namespace SistemaServicios.Tests.Unit;
 
 /// <summary>
-/// Pruebas unitarias del AdminController.
-/// Verifican el mapeo de respuestas HTTP: 201 en éxito y 500 en fallo.
-/// La autorización ([Authorize(Roles = "Admin")]) se prueba en las pruebas de integración.
+/// Despachador falso que retiene el trabajo encolado en lugar de ejecutarlo.
+/// Permite comprobar por separado que el controller encola, y qué hace ese trabajo.
+/// </summary>
+internal sealed class FakeDispatcher : IBackgroundTaskDispatcher
+{
+    public Func<IServiceProvider, CancellationToken, ValueTask>? WorkItem { get; private set; }
+
+    public int EnqueueCount { get; private set; }
+
+    public ValueTask EnqueueAsync(Func<IServiceProvider, CancellationToken, ValueTask> workItem)
+    {
+        WorkItem = workItem;
+        EnqueueCount++;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<Func<IServiceProvider, CancellationToken, ValueTask>> DequeueAsync(
+        CancellationToken cancellationToken
+    ) => throw new NotSupportedException("El falso no consume la cola.");
+}
+
+/// <summary>
+/// Pruebas unitarias del AdminController tras pasar el respaldo a segundo plano.
+/// El controller ya no espera a pg_dump: acepta el trabajo y responde 202.
 /// </summary>
 public class AdminControllerTests
 {
     private readonly Mock<IBackupService> _mockBackupService;
+    private readonly FakeDispatcher _dispatcher;
+    private readonly BackupJobTracker _tracker;
     private readonly AdminController _controller;
 
     public AdminControllerTests()
     {
         _mockBackupService = new Mock<IBackupService>();
+        _dispatcher = new FakeDispatcher();
+        _tracker = new BackupJobTracker();
         _controller = new AdminController(
             _mockBackupService.Object,
+            _dispatcher,
+            _tracker,
             NullLogger<AdminController>.Instance
         );
     }
 
+    /// <summary>Proveedor que resuelve lo que el trabajo encolado necesita.</summary>
+    private IServiceProvider BuildProvider()
+    {
+        var provider = new Mock<IServiceProvider>();
+        _ = provider.Setup(p => p.GetService(typeof(IBackupJobTracker))).Returns(_tracker);
+        _ = provider
+            .Setup(p => p.GetService(typeof(IBackupService)))
+            .Returns(_mockBackupService.Object);
+        return provider.Object;
+    }
+
     // ─────────────────────────────────────────────────────────────
-    // POST /api/admin/backup — respuestas HTTP
+    // POST /api/admin/backup — encolado
     // ─────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task CreateBackupExitosoRetorna201()
+    public async Task CreateBackupRetorna202YNoEsperaAPgDump()
+    {
+        // Act
+        var result = await _controller.CreateBackup();
+
+        // Assert: antes devolvía 201 tras esperar al volcado completo
+        var accepted = result.Should().BeOfType<AcceptedResult>().Subject;
+        _ = accepted.StatusCode.Should().Be(202);
+        _mockBackupService.Verify(s => s.GenerateBackupAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateBackupDevuelveUnTrabajoPendiente()
+    {
+        // Act
+        var result = await _controller.CreateBackup();
+
+        // Assert
+        var job = (result as AcceptedResult)!.Value.Should().BeOfType<BackupJobDto>().Subject;
+        _ = job.Id.Should().NotBeEmpty();
+        _ = job.Status.Should().Be(BackupJobStatus.Pendiente);
+    }
+
+    [Fact]
+    public async Task CreateBackupEncolaElTrabajoUnaVez()
+    {
+        // Act
+        _ = await _controller.CreateBackup();
+
+        // Assert
+        _ = _dispatcher.EnqueueCount.Should().Be(1);
+        _ = _dispatcher.WorkItem.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateBackupDosVecesSeguidasNoLanzaDosPgDump()
+    {
+        // Arrange & Act: segunda petición con el primer trabajo aún sin terminar
+        var primera = await _controller.CreateBackup();
+        var segunda = await _controller.CreateBackup();
+
+        // Assert: se devuelve el mismo trabajo y se encola una sola vez
+        var jobPrimera = (primera as AcceptedResult)!.Value as BackupJobDto;
+        var jobSegunda = (segunda as AcceptedResult)!.Value as BackupJobDto;
+
+        _ = jobSegunda!.Id.Should().Be(jobPrimera!.Id);
+        _ = _dispatcher.EnqueueCount.Should().Be(1);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // El trabajo encolado
+    // ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TrabajoEncoladoExitosoDejaElEstadoEnCompletado()
     {
         // Arrange
         _ = _mockBackupService
@@ -41,110 +134,95 @@ public class AdminControllerTests
             .ReturnsAsync(
                 new BackupResponseDto
                 {
-                    FileName = "backup_20260226_1000.sql",
-                    CreatedAt = DateTime.UtcNow,
-                    FileSizeBytes = 4096,
+                    FileName = "backup_20260813_1200.sql",
+                    FileSizeBytes = 2048,
                 }
             );
 
-        // Act
         var result = await _controller.CreateBackup();
+        var job = (result as AcceptedResult)!.Value as BackupJobDto;
+
+        // Act: se ejecuta el trabajo tal como lo haría el servicio en segundo plano
+        await _dispatcher.WorkItem!(BuildProvider(), CancellationToken.None);
 
         // Assert
-        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-        _ = objectResult.StatusCode.Should().Be(201);
+        var final = _tracker.Find(job!.Id);
+        _ = final!.Status.Should().Be(BackupJobStatus.Completado);
+        _ = final.FileName.Should().Be("backup_20260813_1200.sql");
+        _ = final.FileSizeBytes.Should().Be(2048);
+        _ = final.FinishedAt.Should().NotBeNull();
     }
 
     [Fact]
-    public async Task CreateBackupExitosoRetornaBackupResponseDto()
-    {
-        // Arrange
-        var expected = new BackupResponseDto
-        {
-            FileName = "backup_20260226_1430.sql",
-            CreatedAt = new DateTime(2026, 2, 26, 14, 30, 0, DateTimeKind.Utc),
-            FileSizeBytes = 8192,
-        };
-
-        _ = _mockBackupService.Setup(s => s.GenerateBackupAsync()).ReturnsAsync(expected);
-
-        // Act
-        var result = await _controller.CreateBackup();
-
-        // Assert
-        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-        _ = objectResult.Value.Should().BeEquivalentTo(expected);
-    }
-
-    [Fact]
-    public async Task CreateBackupExitosoLlamaAlServicioExactamenteUnaVez()
-    {
-        // Arrange
-        _ = _mockBackupService
-            .Setup(s => s.GenerateBackupAsync())
-            .ReturnsAsync(new BackupResponseDto { FileName = "backup.sql" });
-
-        // Act
-        _ = await _controller.CreateBackup();
-
-        // Assert: el controller no duplica llamadas al servicio
-        _mockBackupService.Verify(s => s.GenerateBackupAsync(), Times.Once);
-    }
-
-    [Fact]
-    public async Task CreateBackupServicioLanzaInvalidOperationExceptionRetorna500()
+    public async Task TrabajoEncoladoQueFallaDejaElEstadoEnFallidoSinFiltrarDetalle()
     {
         // Arrange
         _ = _mockBackupService
             .Setup(s => s.GenerateBackupAsync())
             .ThrowsAsync(
-                new InvalidOperationException("pg_dump falló (código 1): conexión rechazada")
+                new InvalidOperationException("pg_dump falló (código 1): /var/backups/gsp/x.sql")
             );
 
-        // Act
         var result = await _controller.CreateBackup();
+        var job = (result as AcceptedResult)!.Value as BackupJobDto;
 
-        // Assert
-        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-        _ = objectResult.StatusCode.Should().Be(500);
+        // Act
+        await _dispatcher.WorkItem!(BuildProvider(), CancellationToken.None);
+
+        // Assert: el detalle interno queda en el log, no en el estado consultable
+        var final = _tracker.Find(job!.Id);
+        _ = final!.Status.Should().Be(BackupJobStatus.Fallido);
+        _ = final.Error.Should().NotContain("pg_dump");
+        _ = final.Error.Should().NotContain("/var/backups");
     }
 
     [Fact]
-    public async Task CreateBackupServicioFallaNoFiltraElDetalleInternoAlCliente()
+    public async Task TrasFallarUnTrabajoSePuedeLanzarOtro()
     {
-        // Arrange: el mensaje real arrastra rutas del contenedor y la salida de pg_dump.
-        // Esta prueba afirmaba antes lo contrario — que el detalle SÍ se propagaba —;
-        // se invierte a propósito como parte del issue #133.
-        const string mensajeInterno =
-            "pg_dump falló (código 1): /var/backups/gsp/backup.sql conexión rechazada";
-
+        // Arrange: un trabajo que falla no debe bloquear los siguientes
         _ = _mockBackupService
             .Setup(s => s.GenerateBackupAsync())
-            .ThrowsAsync(new InvalidOperationException(mensajeInterno));
+            .ThrowsAsync(new InvalidOperationException("falló"));
+
+        var primera = await _controller.CreateBackup();
+        await _dispatcher.WorkItem!(BuildProvider(), CancellationToken.None);
 
         // Act
-        var result = await _controller.CreateBackup();
+        var segunda = await _controller.CreateBackup();
 
         // Assert
-        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
-        _ = objectResult.StatusCode.Should().Be(500);
+        var jobPrimera = (primera as AcceptedResult)!.Value as BackupJobDto;
+        var jobSegunda = (segunda as AcceptedResult)!.Value as BackupJobDto;
+        _ = jobSegunda!.Id.Should().NotBe(jobPrimera!.Id);
+        _ = _dispatcher.EnqueueCount.Should().Be(2);
+    }
 
-        var cuerpo = objectResult.Value!.ToString();
-        _ = cuerpo.Should().NotContain("pg_dump");
-        _ = cuerpo.Should().NotContain("/var/backups");
-        _ = cuerpo.Should().Contain("No se pudo generar el respaldo");
+    // ─────────────────────────────────────────────────────────────
+    // GET /api/admin/backup/jobs/{id}
+    // ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetBackupJobConIdExistenteRetorna200()
+    {
+        // Arrange
+        var creado = await _controller.CreateBackup();
+        var job = (creado as AcceptedResult)!.Value as BackupJobDto;
+
+        // Act
+        var result = _controller.GetBackupJob(job!.Id);
+
+        // Assert
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        _ = (ok.Value as BackupJobDto)!.Id.Should().Be(job.Id);
     }
 
     [Fact]
-    public async Task CreateBackupExcepcionNoEsperadaNoesCapturadayBurbujeoHaciaArriba()
+    public void GetBackupJobConIdInexistenteRetorna404()
     {
-        // Arrange: el controller solo captura InvalidOperationException.
-        // Cualquier otra excepción debe burbujear para que el middleware la maneje.
-        _ = _mockBackupService
-            .Setup(s => s.GenerateBackupAsync())
-            .ThrowsAsync(new IOException("error inesperado"));
+        // Act
+        var result = _controller.GetBackupJob(Guid.NewGuid());
 
-        // Act & Assert
-        _ = await Assert.ThrowsAsync<IOException>(() => _controller.CreateBackup());
+        // Assert
+        _ = result.Should().BeOfType<NotFoundObjectResult>();
     }
 }

--- a/backend/SistemaServicios.Tests/Unit/BackupJobTrackerTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/BackupJobTrackerTests.cs
@@ -1,0 +1,148 @@
+using FluentAssertions;
+using SistemaServicios.API.DTOs.Admin;
+using SistemaServicios.API.Services;
+using Xunit;
+
+namespace SistemaServicios.Tests.Unit;
+
+public class BackupJobTrackerTests
+{
+    private readonly BackupJobTracker _tracker = new();
+
+    [Fact]
+    public void StartOrGetActiveCreaUnTrabajoPendiente()
+    {
+        // Act
+        var (job, created) = _tracker.StartOrGetActive();
+
+        // Assert
+        _ = created.Should().BeTrue();
+        _ = job.Status.Should().Be(BackupJobStatus.Pendiente);
+    }
+
+    [Fact]
+    public void StartOrGetActiveConTrabajoPendienteDevuelveElMismo()
+    {
+        // Arrange
+        var (primero, _) = _tracker.StartOrGetActive();
+
+        // Act
+        var (segundo, created) = _tracker.StartOrGetActive();
+
+        // Assert: sin esto, dos peticiones lanzarían dos pg_dump a la vez
+        _ = created.Should().BeFalse();
+        _ = segundo.Id.Should().Be(primero.Id);
+    }
+
+    [Fact]
+    public void StartOrGetActiveConTrabajoEnProcesoDevuelveElMismo()
+    {
+        // Arrange
+        var (primero, _) = _tracker.StartOrGetActive();
+        _tracker.MarkRunning(primero.Id);
+
+        // Act
+        var (segundo, created) = _tracker.StartOrGetActive();
+
+        // Assert
+        _ = created.Should().BeFalse();
+        _ = segundo.Id.Should().Be(primero.Id);
+    }
+
+    [Fact]
+    public void StartOrGetActiveTrasCompletarCreaUnoNuevo()
+    {
+        // Arrange
+        var (primero, _) = _tracker.StartOrGetActive();
+        _tracker.MarkCompleted(primero.Id, "backup_20260813_1200.sql", 100);
+
+        // Act
+        var (segundo, created) = _tracker.StartOrGetActive();
+
+        // Assert
+        _ = created.Should().BeTrue();
+        _ = segundo.Id.Should().NotBe(primero.Id);
+    }
+
+    [Fact]
+    public void StartOrGetActiveTrasFallarCreaUnoNuevo()
+    {
+        // Arrange: un fallo no debe dejar bloqueada la funcionalidad
+        var (primero, _) = _tracker.StartOrGetActive();
+        _tracker.MarkFailed(primero.Id, "algo salió mal");
+
+        // Act
+        var (_, created) = _tracker.StartOrGetActive();
+
+        // Assert
+        _ = created.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MarkCompletedGuardaNombreTamanoYFechaDeFin()
+    {
+        // Arrange
+        var (job, _) = _tracker.StartOrGetActive();
+
+        // Act
+        _tracker.MarkCompleted(job.Id, "backup_20260813_1200.sql", 4096);
+
+        // Assert
+        var final = _tracker.Find(job.Id);
+        _ = final!.Status.Should().Be(BackupJobStatus.Completado);
+        _ = final.FileName.Should().Be("backup_20260813_1200.sql");
+        _ = final.FileSizeBytes.Should().Be(4096);
+        _ = final.FinishedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void FindConIdInexistenteDevuelveNull()
+    {
+        // Act & Assert
+        _ = _tracker.Find(Guid.NewGuid()).Should().BeNull();
+    }
+
+    [Fact]
+    public void FailActiveJobsMarcaLosSinTerminar()
+    {
+        // Arrange: es lo que se ejecuta al apagar el proceso
+        var (pendiente, _) = _tracker.StartOrGetActive();
+        _tracker.MarkRunning(pendiente.Id);
+
+        // Act
+        _tracker.FailActiveJobs("El servicio se detuvo.");
+
+        // Assert: sin esto, el trabajo quedaría en EnProceso para siempre y
+        // bloquearía cualquier respaldo posterior
+        var final = _tracker.Find(pendiente.Id);
+        _ = final!.Status.Should().Be(BackupJobStatus.Fallido);
+        _ = final.Error.Should().Be("El servicio se detuvo.");
+    }
+
+    [Fact]
+    public void FailActiveJobsNoTocaLosYaCompletados()
+    {
+        // Arrange
+        var (job, _) = _tracker.StartOrGetActive();
+        _tracker.MarkCompleted(job.Id, "backup_20260813_1200.sql", 10);
+
+        // Act
+        _tracker.FailActiveJobs("El servicio se detuvo.");
+
+        // Assert
+        _ = _tracker.Find(job.Id)!.Status.Should().Be(BackupJobStatus.Completado);
+    }
+
+    [Fact]
+    public async Task StartOrGetActiveEsSeguroAnteLlamadasConcurrentes()
+    {
+        // Arrange & Act: veinte peticiones simultáneas
+        var resultados = await Task.WhenAll(
+            Enumerable.Range(0, 20).Select(_ => Task.Run(() => _tracker.StartOrGetActive()))
+        );
+
+        // Assert: exactamente una crea el trabajo; el resto recibe el mismo
+        _ = resultados.Count(r => r.created).Should().Be(1);
+        _ = resultados.Select(r => r.job.Id).Distinct().Should().ContainSingle();
+    }
+}

--- a/backend/SistemaServicios.Tests/Unit/EmailServiceTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/EmailServiceTests.cs
@@ -1,55 +1,132 @@
 using System.Net.Mail;
 using Microsoft.Extensions.Configuration;
 using SistemaServicios.API.Interfaces;
+using SistemaServicios.API.Services;
+using Xunit;
 
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("SistemaServicios.Tests")]
+namespace SistemaServicios.Tests.Unit;
 
-namespace SistemaServicios.API.Services;
-
-public class EmailService : IEmailService
+public class EmailServiceTests
 {
-    private readonly ISmtpClientWrapper _smtpClient;
-    private readonly string _from;
-
-    public EmailService(IConfiguration config, ISmtpClientWrapper? smtpClient = null)
+    private sealed class FakeSmtpClient : ISmtpClientWrapper
     {
-        var host =
-            config["SmtpSettings:Host"]
-            ?? throw new InvalidOperationException("SMTP_HOST no configurado.");
-        var port = int.Parse(
-            config["SmtpSettings:Port"] ?? "587",
-            System.Globalization.CultureInfo.InvariantCulture
-        );
-        var user =
-            config["SmtpSettings:User"]
-            ?? throw new InvalidOperationException("SMTP_USER no configurado.");
-        var password =
-            config["SmtpSettings:Password"]
-            ?? throw new InvalidOperationException("SMTP_PASSWORD no configurado.");
+        public MailMessage? MensajeEnviado { get; private set; }
+        public bool DebeFallar { get; set; }
 
-        _from = config["SmtpSettings:From"] ?? user;
-        _smtpClient = smtpClient ?? new SmtpClientWrapper(host, port, user, password);
-    }
-
-    public async Task SendPasswordResetEmailAsync(string toEmail, string newPassword)
-    {
-        var message = new MailMessage
+        public Task SendMailAsync(MailMessage message)
         {
-            From = new MailAddress(_from, "SistemaServicios"),
-            Subject = "Tu nueva contraseña — SistemaServicios",
-            Body = BuildEmailBody(newPassword),
-            IsBodyHtml = true,
-        };
-        message.To.Add(toEmail);
+            if (DebeFallar)
+            {
+                throw new SmtpException("fallo simulado");
+            }
 
-        await _smtpClient.SendMailAsync(message);
+            MensajeEnviado = message;
+            return Task.CompletedTask;
+        }
+
+        public void Dispose() { }
     }
 
-    internal static string BuildEmailBody(string newPassword) =>
-        $"""
-            <h2>Recuperación de contraseña</h2>
-            <p>Tu nueva contraseña temporal es:</p>
-            <h3 style="letter-spacing:2px">{newPassword}</h3>
-            <p>Te recomendamos cambiarla después de iniciar sesión.</p>
-            """;
+    private static IConfiguration BuildConfig(
+        string? host = "smtp.test.com",
+        string? port = "587",
+        string? user = "user@test.com",
+        string? password = "secret",
+        string? from = null
+    )
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["SmtpSettings:Host"] = host,
+            ["SmtpSettings:Port"] = port,
+            ["SmtpSettings:User"] = user,
+            ["SmtpSettings:Password"] = password,
+            ["SmtpSettings:From"] = from,
+        };
+        return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+    }
+
+    [Fact]
+    public void ConstructorConfigValidaNoLanzaExcepcion()
+    {
+        var ex = Record.Exception(() => new EmailService(BuildConfig(), new FakeSmtpClient()));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ConstructorSinHostLanzaInvalidOperation()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new EmailService(BuildConfig(host: null), new FakeSmtpClient())
+        );
+        Assert.Contains("SMTP_HOST", ex.Message);
+    }
+
+    [Fact]
+    public void ConstructorSinUserLanzaInvalidOperation()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new EmailService(BuildConfig(user: null), new FakeSmtpClient())
+        );
+        Assert.Contains("SMTP_USER", ex.Message);
+    }
+
+    [Fact]
+    public void ConstructorSinPasswordLanzaInvalidOperation()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new EmailService(BuildConfig(password: null), new FakeSmtpClient())
+        );
+        Assert.Contains("SMTP_PASSWORD", ex.Message);
+    }
+
+    [Fact]
+    public void ConstructorSinFromUsaUserComoFrom()
+    {
+        var ex = Record.Exception(() =>
+            new EmailService(BuildConfig(from: null), new FakeSmtpClient())
+        );
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ConstructorPuertoInvalidoLanzaFormatException()
+    {
+        Assert.Throws<FormatException>(() =>
+            new EmailService(BuildConfig(port: "abc"), new FakeSmtpClient())
+        );
+    }
+
+    [Fact]
+    public async Task SendPasswordResetEmailAsyncEnviaMensajeCorrecto()
+    {
+        var fake = new FakeSmtpClient();
+        var service = new EmailService(BuildConfig(), fake);
+
+        await service.SendPasswordResetEmailAsync("dest@test.com", "Pass123!");
+
+        Assert.NotNull(fake.MensajeEnviado);
+        Assert.Equal("dest@test.com", fake.MensajeEnviado!.To[0].Address);
+        Assert.Contains("Tu nueva contraseña", fake.MensajeEnviado.Subject);
+        Assert.True(fake.MensajeEnviado.IsBodyHtml);
+    }
+
+    [Fact]
+    public async Task SendPasswordResetEmailAsyncSmtpFallaPropagaExcepcion()
+    {
+        var fake = new FakeSmtpClient { DebeFallar = true };
+        var service = new EmailService(BuildConfig(), fake);
+
+        await Assert.ThrowsAsync<SmtpException>(() =>
+            service.SendPasswordResetEmailAsync("dest@test.com", "Pass123!")
+        );
+    }
+
+    [Fact]
+    public void BuildEmailBodyContienePasswordYHtml()
+    {
+        var body = EmailService.BuildEmailBody("MiPass99");
+        Assert.Contains("MiPass99", body);
+        Assert.Contains("<h2>", body);
+    }
 }

--- a/backend/SistemaServicios.Tests/Unit/ForgotPasswordServiceTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/ForgotPasswordServiceTests.cs
@@ -185,22 +185,23 @@ public class ForgotPasswordServiceTests
     // ForgotPasswordAsync — errores esperados
     // ─────────────────────────────────────────────────────────────
 
+    // Antes, estas rutas lanzaban excepciones con mensajes distintos y el controller
+    // las devolvía al cliente. La de cuenta desactivada confirmaba que el correo
+    // estaba registrado: enumeración de cuentas. Ahora ambas terminan en silencio.
+
     [Fact]
-    public async Task ForgotPasswordAsyncEmailNoRegistradoLanzaInvalidOperationException()
+    public async Task ForgotPasswordAsyncEmailNoRegistradoTerminaEnSilencio()
     {
         // Arrange: el repositorio devuelve null (usuario no encontrado)
         _ = _mockRepo.Setup(r => r.GetByEmailAsync(It.IsAny<string>())).ReturnsAsync((User?)null);
 
         var dto = new ForgotPasswordRequestDto { Email = "noexiste@test.com" };
 
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _authService.ForgotPasswordAsync(dto)
-        );
+        // Act
+        var ex = await Record.ExceptionAsync(() => _authService.ForgotPasswordAsync(dto));
 
-        _ = ex
-            .Message.Should()
-            .Be("Si el correo está registrado, recibirás tu nueva contraseña en breve.");
+        // Assert: no lanza, para que la respuesta no dependa de si la cuenta existe
+        _ = ex.Should().BeNull();
     }
 
     [Fact]
@@ -212,9 +213,7 @@ public class ForgotPasswordServiceTests
         var dto = new ForgotPasswordRequestDto { Email = "noexiste@test.com" };
 
         // Act
-        _ = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _authService.ForgotPasswordAsync(dto)
-        );
+        await _authService.ForgotPasswordAsync(dto);
 
         // Assert: nunca se actualiza la DB ni se envía email
         _mockRepo.Verify(r => r.UpdateUserAsync(It.IsAny<User>()), Times.Never);
@@ -225,7 +224,7 @@ public class ForgotPasswordServiceTests
     }
 
     [Fact]
-    public async Task ForgotPasswordAsyncCuentaDesactivadaLanzaInvalidOperationException()
+    public async Task ForgotPasswordAsyncCuentaDesactivadaTerminaEnSilencio()
     {
         // Arrange: usuario con Status = false
         var usuarioInactivo = new User
@@ -245,12 +244,12 @@ public class ForgotPasswordServiceTests
 
         var dto = new ForgotPasswordRequestDto { Email = "inactivo@test.com" };
 
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _authService.ForgotPasswordAsync(dto)
-        );
+        // Act
+        var ex = await Record.ExceptionAsync(() => _authService.ForgotPasswordAsync(dto));
 
-        _ = ex.Message.Should().Be("La cuenta está desactivada.");
+        // Assert: no lanza y no revela que la cuenta existe. Esta prueba afirmaba antes
+        // lo contrario, que el mensaje era "La cuenta está desactivada."
+        _ = ex.Should().BeNull();
     }
 
     [Fact]
@@ -275,9 +274,7 @@ public class ForgotPasswordServiceTests
         var dto = new ForgotPasswordRequestDto { Email = "inactivo@test.com" };
 
         // Act
-        _ = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _authService.ForgotPasswordAsync(dto)
-        );
+        await _authService.ForgotPasswordAsync(dto);
 
         // Assert: nada se ejecuta después de detectar cuenta desactivada
         _mockRepo.Verify(r => r.UpdateUserAsync(It.IsAny<User>()), Times.Never);

--- a/backend/SistemaServicios.Tests/Unit/QueuedEmailServiceTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/QueuedEmailServiceTests.cs
@@ -1,0 +1,135 @@
+using System.Net.Mail;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SistemaServicios.API.Interfaces;
+using SistemaServicios.API.Services;
+using Xunit;
+
+namespace SistemaServicios.Tests.Unit;
+
+/// <summary>
+/// Pruebas del envío de correo en segundo plano. Lo relevante es que la llamada retorna
+/// sin esperar al servidor SMTP —antes el tiempo de respuesta del usuario dependía de la
+/// latencia del proveedor— y que los fallos transitorios se reintentan sin llegar a él.
+/// </summary>
+public class QueuedEmailServiceTests
+{
+    private readonly FakeDispatcher _dispatcher = new();
+    private readonly Mock<ISmtpClientWrapper> _smtp = new();
+    private readonly QueuedEmailService _service;
+
+    public QueuedEmailServiceTests()
+    {
+        _service = new QueuedEmailService(
+            _dispatcher,
+            NullLogger<QueuedEmailService>.Instance,
+            // Sin espera real: si no, ejercitar los tres intentos costaría seis segundos.
+            TimeSpan.Zero
+        );
+    }
+
+    /// <summary>Proveedor que resuelve el EmailService real con un SMTP controlado.</summary>
+    private IServiceProvider BuildProvider()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["SmtpSettings:Host"] = "smtp.test",
+                    ["SmtpSettings:Port"] = "587",
+                    ["SmtpSettings:User"] = "test@test.com",
+                    ["SmtpSettings:Password"] = "clave",
+                    ["SmtpSettings:From"] = "test@test.com",
+                }
+            )
+            .Build();
+
+        var emailService = new EmailService(config, _smtp.Object);
+
+        var provider = new Mock<IServiceProvider>();
+        _ = provider.Setup(p => p.GetService(typeof(EmailService))).Returns(emailService);
+        return provider.Object;
+    }
+
+    private async Task EjecutarTrabajoEncolado() =>
+        await _dispatcher.WorkItem!(BuildProvider(), CancellationToken.None);
+
+    // ─────────────────────────────────────────────────────────────
+    // Encolado
+    // ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SendPasswordResetEmailAsyncEncolaYNoEnviaEnLaPeticion()
+    {
+        // Act
+        await _service.SendPasswordResetEmailAsync("juan@test.com", "NuevaPass123");
+
+        // Assert: el envío no ocurre dentro de la petición
+        _ = _dispatcher.EnqueueCount.Should().Be(1);
+        _smtp.Verify(s => s.SendMailAsync(It.IsAny<MailMessage>()), Times.Never);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Reintentos
+    // ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TrabajoEncoladoEnviaUnaSolaVezSiElPrimerIntentoFunciona()
+    {
+        // Arrange
+        _ = _smtp.Setup(s => s.SendMailAsync(It.IsAny<MailMessage>())).Returns(Task.CompletedTask);
+        await _service.SendPasswordResetEmailAsync("juan@test.com", "NuevaPass123");
+
+        // Act
+        await EjecutarTrabajoEncolado();
+
+        // Assert
+        _smtp.Verify(s => s.SendMailAsync(It.IsAny<MailMessage>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task TrabajoEncoladoReintentaTrasUnFalloTransitorio()
+    {
+        // Arrange: falla el primer intento y funciona el segundo
+        var intentos = 0;
+        _ = _smtp
+            .Setup(s => s.SendMailAsync(It.IsAny<MailMessage>()))
+            .Returns(() =>
+            {
+                intentos++;
+                return intentos == 1
+                    ? Task.FromException(new InvalidOperationException("fallo transitorio"))
+                    : Task.CompletedTask;
+            });
+
+        await _service.SendPasswordResetEmailAsync("juan@test.com", "NuevaPass123");
+
+        // Act
+        await EjecutarTrabajoEncolado();
+
+        // Assert
+        _ = intentos.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task TrabajoEncoladoSeRindeTrasTresIntentosSinPropagarLaExcepcion()
+    {
+        // Arrange: el proveedor está caído de forma permanente
+        _ = _smtp
+            .Setup(s => s.SendMailAsync(It.IsAny<MailMessage>()))
+            .ThrowsAsync(new InvalidOperationException("SMTP caído"));
+
+        await _service.SendPasswordResetEmailAsync("juan@test.com", "NuevaPass123");
+
+        // Act
+        var ex = await Record.ExceptionAsync(EjecutarTrabajoEncolado);
+
+        // Assert: tres intentos y ninguna excepción escapa. Propagarla tumbaría el
+        // consumidor de la cola; además, el usuario nunca debe enterarse de este fallo,
+        // porque saber que su correo no salió revelaría que la cuenta existe.
+        _ = ex.Should().BeNull();
+        _smtp.Verify(s => s.SendMailAsync(It.IsAny<MailMessage>()), Times.Exactly(3));
+    }
+}


### PR DESCRIPTION
## 📌 Resumen del Cambio

El respaldo de base de datos y el envío de correo se ejecutaban **dentro de la petición HTTP**. El administrador que pulsaba "generar respaldo" mantenía una petición abierta durante todo el `pg_dump`, y el flujo de recuperación de contraseña quedaba a merced de la latencia del servidor SMTP.

Ambos pasan a una cola en segundo plano. `POST /api/Admin/backup` responde **202** de inmediato y el estado se consulta aparte.

Incluye además la corrección de una **enumeración de cuentas** en `forgot-password`, descubierta al revisar el flujo de correo.

---

## 🔍 Tipo de Cambio realizado

- [x] 🐞 Corrección de error (`fix`)
- [ ] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [x] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [x] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

**Nuevos**
- `Interfaces/IBackgroundTaskDispatcher.cs`, `Services/BackgroundTaskDispatcher.cs` — cola sobre `Channel<T>`
- `Services/QueuedHostedService.cs` — consumidor
- `Interfaces/IBackupJobTracker.cs`, `Services/BackupJobTracker.cs`, `DTOs/Admin/BackupJobDto.cs` — estado de trabajos
- `Services/QueuedEmailService.cs` — decorador con reintentos
- `Tests/Unit/BackupJobTrackerTests.cs`, `Tests/Unit/QueuedEmailServiceTests.cs`

**Modificados**
- `Controllers/AdminController.cs` — 202 y endpoint de estado
- `Services/AuthService.cs` — flujo uniforme en `forgot-password`
- `Extensions/ApplicationServiceExtensions.cs` — registro de la cola y el decorador
- `Tests/Unit/AdminControllerTests.cs`, `Tests/Unit/ForgotPasswordServiceTests.cs`, `Tests/Integration/AdminControllerTests.cs`

---

## 🧪 ¿Cómo Probarlo?

```bash
dotnet run --project backend/SistemaServicios.API
```

En `http://localhost:5000/swagger`, con token de Admin:

1. `POST /api/Admin/backup` responde **202** al instante, con `{ id, status: "Pendiente" }`. Antes bloqueaba hasta terminar el volcado.
2. `GET /api/Admin/backup/jobs/{id}` pasa de `Pendiente` a `EnProceso` y luego a `Completado`, con nombre y tamaño del archivo.
3. Pulsar dos veces seguidas devuelve **el mismo id**: no se lanzan dos `pg_dump`.
4. `GET /api/Admin/backups` lista el archivo ya generado.

Para la recuperación de contraseña, `POST /api/Auth/forgot-password`: la respuesta es inmediata y **el mismo mensaje** exista la cuenta, no exista, o esté desactivada.

```bash
cd backend && dotnet test
```

---

## ✅ Checklist

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [x] Se han actualizado o agregado pruebas
- [x] La documentación se actualizó si fue necesario
- [x] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Closes #126

### Un criterio del issue se descartó, y seguirlo habría sido un error

El issue pedía escribir los respaldos en object storage **reutilizando `IFileStorage`** de #125. Tras aquel trabajo, la única implementación de producción de esa interfaz es `DbFileStorage`, que guarda en PostgreSQL: **meter los respaldos de la base dentro de la propia base es circular**. Si se pierde la base, se pierden los respaldos con ella, que es justo lo que un respaldo debe evitar.

Los respaldos siguen en `BACKUP_DIR`. Bajo la restricción de no contratar servicios, la salida real es que el administrador **descargue** el `.sql`, cosa que #133 ya permite.

Otros tres criterios del issue ya los había cerrado #133: el `Dockerfile` instala `postgresql-client`, el destino es configurable, y `PGPASSWORD` viaja por entorno y no en la línea de comandos.

### Enumeración de cuentas corregida

`forgot-password` respondía **"La cuenta está desactivada."** cuando el correo existía pero la cuenta estaba inactiva. Eso confirmaba el registro, pese a que el comentario del código decía *"200 intencional: no revelar existencia del email"*. Además, el camino sin cuenta terminaba al instante mientras que el camino con cuenta hacía BCrypt y esperaba al SMTP completo.

Ahora la cuenta inexistente y la desactivada terminan igual y en silencio, y se calcula un **hash de descarte** para que el camino sin cuenta no acabe antes y delate por tiempo lo que el mensaje ya no delata.

**Alcance honesto:** encolar el correo elimina la diferencia de *segundos*. Queda una de milisegundos por el hash, que el descarte iguala en la práctica pero no garantiza formalmente. No es tiempo constante demostrable.

### Una prueba encontró un fallo en la primera versión de este código

Para poder ejercitar los tres reintentos sin esperar seis segundos reales, la base del backoff se hizo inyectable. Esa prueba reveló que el filtro `when (intento < MaxIntentos)` **dejaba escapar la excepción del último intento**: se propagaba fuera del trabajo y el registro del fallo definitivo era código inalcanzable. En producción, un SMTP caído de forma permanente no habría dejado rastro del fallo final.

### Decisiones de diseño

**Cola en proceso, no Redis.** `Channel<T>` más un `BackgroundService` no añaden infraestructura, en coherencia con la restricción de no contratar servicios. La contrapartida es real: **los trabajos pendientes se pierden si el proceso muere**. Es asumible para respaldos y correos de recuperación, que el usuario puede repetir.

**Guardia contra concurrencia.** Dos peticiones simultáneas no lanzan dos `pg_dump` contra la misma base: la segunda recibe el trabajo en curso. Hay una prueba con veinte llamadas concurrentes que verifica que solo una crea el trabajo.

**Apagado limpio.** Al detener el servicio, los trabajos sin terminar se marcan como fallidos. Sin eso, uno interrumpido quedaría en `EnProceso` para siempre y el guardia impediría lanzar cualquier respaldo posterior.

**El decorador no toca a quien lo usa.** `QueuedEmailService` envuelve al `EmailService` real; `AuthService` sigue dependiendo de `IEmailService` sin enterarse.

### Cambios de comportamiento

`POST /api/Admin/backup` devuelve **202 en lugar de 201**, y ya no puede devolver 500: el fallo ocurre fuera de la petición y queda en el estado del trabajo. Quien consuma este endpoint debe adaptarse — hoy solo lo consume Swagger, porque la pantalla de #158 aún no está integrada en el panel.

**Diez pruebas se actualizaron, ninguna se eliminó.** Cuatro de `forgot-password` afirmaban exactamente el comportamiento vulnerable; el resto esperaba 201 tras el volcado completo. Las de integración ahora verifican la tubería entera: aceptan el 202 y **esperan a que el trabajo llegue a estado final**, lo que comprueba que el consumidor en segundo plano ejecuta de verdad.


### Segundo commit: arreglo de una regresión que llegó desde `dev`

Al rebasar sobre `dev` no hubo conflicto textual, pero sí uno **semántico** que el rebase ocultó.

**[#142](https://github.com/vidanj/Gestion-Servicios-Profesionales/pull/142) sustituyó `Tests/Unit/EmailServiceTests.cs` por una copia literal de la clase de producción `EmailService`**, declarada además en el namespace `SistemaServicios.API.Services`. El archivo pasó de **nueve pruebas a cero**.

Dos efectos:

1. **La copia sombreaba a la clase real dentro del ensamblado de pruebas.** Cualquier prueba que mencionara `EmailService` compilaba contra el duplicado y no contra el código desplegado. Como nada lo mencionaba por su nombre, el conflicto no se manifestaba: se hizo visible al añadir yo la primera prueba que lo usa (`CS0436`).

2. **El motivo por el que se llegó ahí.** Tres de las nueve pruebas afirmaban que `EmailService` lanza si faltan `SMTP_HOST`, `SMTP_USER` o `SMTP_PASSWORD`. Al cambiar el servicio para caer en valores de relleno (`smtp.test.com`, `test@test.com`, `password`) esas tres empezaron a fallar, y se resolvió borrando el archivo en vez de aportar configuración al entorno de pruebas.

**El riesgo en producción no es teórico, y esta misma PR lo agravaba.** Con valores por defecto, un SMTP mal configurado no da ningún síntoma: la aplicación arranca, acepta la petición de recuperación y el correo no llega. Antes, la falta de configuración impedía arrancar. Con el encolado que introduce este PR, además, el envío se reintenta tres veces y el fallo definitivo se registra sin llegar nunca al usuario — sin el arranque ruidoso, nadie se entera.

Se restauran las nueve pruebas y la validación. La configuración SMTP del entorno de pruebas pasa a `CustomWebApplicationFactory`, junto a la de JWT y base de datos.

> ⚠️ **Antes de mergear:** verificar que Render tenga definidas `SMTP_HOST`, `SMTP_USER` y `SMTP_PASSWORD`. Con la validación restaurada, si faltan **la aplicación no arrancará**. Es el comportamiento correcto —falla ruidosa en vez de silenciosa— pero conviene comprobarlo antes y no después.

**Conteo de pruebas:** `dev` está hoy en 232. Esta rama deja **260**: 19 nuevas de este trabajo más las 9 restauradas.


### Tercer commit: `dev` no compilaba

Los merges de los PR **#151, #152 y #154** dejaron `Data/AppDbContext.cs` con seis violaciones de StyleCop: dos bloques de comentario pegados a la instrucción anterior sin línea en blanco (`SA1515`) y una línea en blanco antes de la llave de cierre (`SA1508`). Con `TreatWarningsAsErrors`, eso **impide compilar la solución**.

Se verificó en un worktree limpio de `dev`, sin esta rama: **el fallo está en `dev` por sí solo.**

Detalle que explica por qué pasó desapercibido: **`csharpier check` pasa**. Esas dos reglas son de StyleCop, no de CSharpier, así que `backend-lint` queda verde mientras `backend-tests` no puede compilar.

Son tres líneas en blanco, sin ningún cambio de comportamiento.

### Nota sobre las migraciones

Las dos migraciones que traen esos PR (`20260809020607`, `20260809023901`) tienen fecha **anterior** a la de `AddStoredFiles` (`20260813184350`), que ya estaba en `dev` desde #125. Se comprobó que el orden cronológico queda correcto y que el snapshot conserva las tres aportaciones:

```
dotnet ef migrations has-pending-model-changes
→ No changes have been made to the model since the last migration.
```

### Verificación

Suite completa: **260 pruebas, 0 fallos**, build sin advertencias y CSharpier conforme. `dev` está en 232. CSharpier y los analizadores, limpios con `TreatWarningsAsErrors`.
