### PR TITLE
fix: adapta la pantalla de respaldos al flujo asíncrono y evita nombres duplicados

### DIFF
--- a/backend/SistemaServicios.API/Services/BackupService.cs
+++ b/backend/SistemaServicios.API/Services/BackupService.cs
@@ -45,9 +45,22 @@ public partial class BackupService : IBackupService
         // resolver la dependencia es un efecto secundario en tiempo de arranque.
         _ = Directory.CreateDirectory(_backupDir);
 
-        var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmm", CultureInfo.InvariantCulture);
+        // Con precisión de minuto, dos respaldos del mismo minuto compartían nombre y
+        // el segundo sobrescribía al primero en silencio.
+        var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
         var fileName = $"backup_{timestamp}.sql";
         var filePath = Path.Combine(_backupDir, fileName);
+
+        // Los segundos hacen improbable la colisión, pero no la impiden: dos respaldos
+        // dentro del mismo segundo seguirían compartiendo nombre. Se desambigua con un
+        // sufijo para que ningún respaldo pueda sobrescribir a otro.
+        var sufijo = 2;
+        while (File.Exists(filePath))
+        {
+            fileName = $"backup_{timestamp}_{sufijo}.sql";
+            filePath = Path.Combine(_backupDir, fileName);
+            sufijo++;
+        }
 
         var result = await _processRunner.RunAsync(
             "pg_dump",
@@ -126,7 +139,10 @@ public partial class BackupService : IBackupService
         return File.Exists(fullPath) ? File.OpenRead(fullPath) : null;
     }
 
-    // Patron exacto de los nombres que produce GenerateBackupAsync: backup_yyyyMMdd_HHmm.sql
-    [GeneratedRegex(@"^backup_\d{8}_\d{4}\.sql$", RegexOptions.CultureInvariant)]
+    // Patron de los nombres que produce GenerateBackupAsync. Acepta seis digitos
+    // (HHmmss, formato actual) y cuatro (HHmm, formato anterior): sin esa tolerancia,
+    // los respaldos ya generados dejarian de listarse y de poder descargarse.
+    // El sufijo opcional desambigua respaldos creados dentro del mismo segundo.
+    [GeneratedRegex(@"^backup_\d{8}_(\d{6}|\d{4})(_\d+)?\.sql$", RegexOptions.CultureInvariant)]
     private static partial Regex NombreDeRespaldoValido();
 }

--- a/backend/SistemaServicios.Tests/Unit/BackupServiceTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/BackupServiceTests.cs
@@ -239,7 +239,7 @@ public class BackupServiceTests : IDisposable
         var dto = await service.GenerateBackupAsync();
 
         // Assert
-        _ = dto.FileName.Should().MatchRegex(@"^backup_\d{8}_\d{4}\.sql$");
+        _ = dto.FileName.Should().MatchRegex(@"^backup_\d{8}_\d{6}(_\d+)?\.sql$");
         _ = dto.FileSizeBytes.Should().BeGreaterThan(0);
         _ = File.Exists(Path.Combine(_directorioTemporal, dto.FileName)).Should().BeTrue();
     }
@@ -402,5 +402,56 @@ public class BackupServiceTests : IDisposable
         _ = stream.Should().NotBeNull();
         using var lector = new StreamReader(stream!);
         _ = lector.ReadToEnd().Should().Be("-- contenido");
+    }
+
+    [Fact]
+    public async Task GenerateBackupAsyncDosRespaldosSeguidosNoCompartenNombre()
+    {
+        // Arrange: con precisión de minuto, dos respaldos del mismo minuto producían
+        // el mismo nombre y el segundo sobrescribía al primero sin aviso (issue #162).
+        SetVariablesValidas();
+        SimularPgDumpExitoso();
+        var service = CrearServicio();
+
+        // Act
+        var primero = await service.GenerateBackupAsync();
+        var segundo = await service.GenerateBackupAsync();
+
+        // Assert
+        _ = segundo.FileName.Should().NotBe(primero.FileName);
+        _ = Directory.GetFiles(_directorioTemporal, "*.sql").Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void OpenBackupAceptaElFormatoAntiguoDeCuatroDigitos()
+    {
+        // Arrange: los respaldos creados antes del cambio deben seguir descargándose.
+        // Si la lista blanca solo aceptara seis dígitos, desaparecerían de la lista.
+        _ = Directory.CreateDirectory(_directorioTemporal);
+        const string nombreAntiguo = "backup_20260813_2017.sql";
+        File.WriteAllText(Path.Combine(_directorioTemporal, nombreAntiguo), "-- antiguo");
+        var service = CrearServicio();
+
+        // Act
+        using var stream = service.OpenBackup(nombreAntiguo);
+
+        // Assert
+        _ = stream.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ListBackupsIncluyeAmbosFormatosDeNombre()
+    {
+        // Arrange
+        _ = Directory.CreateDirectory(_directorioTemporal);
+        File.WriteAllText(Path.Combine(_directorioTemporal, "backup_20260813_2017.sql"), "a");
+        File.WriteAllText(Path.Combine(_directorioTemporal, "backup_20260813_201755.sql"), "b");
+        var service = CrearServicio();
+
+        // Act
+        var resultado = service.ListBackups();
+
+        // Assert
+        _ = resultado.Should().HaveCount(2);
     }
 }

--- a/frontend/src/features/respaldos/application/use-backups-controller.ts
+++ b/frontend/src/features/respaldos/application/use-backups-controller.ts
@@ -1,7 +1,15 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-import { Backup, isValidBackupFileName } from "../domain/backup.model";
+import { Backup, esEstadoFinal, isValidBackupFileName } from "../domain/backup.model";
 import { BackupRepository, httpBackupRepository } from "../infrastructure/backup.repository";
+
+/** Cada cuánto se pregunta por el estado del trabajo. */
+const INTERVALO_SONDEO_MS = 1500;
+
+/** Tope del sondeo: sin él, la pantalla giraría para siempre si el servidor calla. */
+const MAX_INTENTOS_SONDEO = 60;
+
+const esperar = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Hook controlador: mantiene el estado de la pantalla y coordina las acciones.
 // El repositorio se inyecta para poder sustituirlo en pruebas.
@@ -11,6 +19,15 @@ export function useBackupsController(repository: BackupRepository = httpBackupRe
   const [isGenerating, setIsGenerating] = useState(false);
   const [downloadingFile, setDownloadingFile] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState("");
+
+  // Evita que un sondeo en curso siga escribiendo estado tras desmontar la pantalla.
+  const montado = useRef(true);
+  useEffect(() => {
+    montado.current = true;
+    return () => {
+      montado.current = false;
+    };
+  }, []);
 
   const loadBackups = useCallback(async () => {
     setIsLoading(true);
@@ -31,21 +48,46 @@ export function useBackupsController(repository: BackupRepository = httpBackupRe
   }, [loadBackups]);
 
   async function generateBackup() {
-    // La generacion es sincrona en el servidor y puede tardar: sin este guardia,
-    // un doble clic dispara dos pg_dump concurrentes.
+    // La generacion es asincrona en el servidor: sin este guardia, un doble clic
+    // encolaria dos peticiones aunque el backend devuelva el mismo trabajo.
     if (isGenerating) return;
 
     setIsGenerating(true);
     setErrorMessage("");
+
     try {
-      await repository.generate();
+      // El POST solo encola: responde 202 con un trabajo todavia sin terminar.
+      const job = await repository.generate();
+
+      // Hay que esperar a que termine de verdad. Recargar la lista aqui mostraria
+      // el estado anterior, porque el archivo aun no existe.
+      let estado = job;
+      for (let intento = 0; !esEstadoFinal(estado.status); intento++) {
+        if (intento >= MAX_INTENTOS_SONDEO) {
+          setErrorMessage(
+            "El respaldo está tardando más de lo esperado. Revisa la lista en unos minutos.",
+          );
+          return;
+        }
+
+        await esperar(INTERVALO_SONDEO_MS);
+        if (!montado.current) return;
+
+        estado = await repository.getJob(job.id);
+      }
+
+      if (estado.status === "Fallido") {
+        setErrorMessage(estado.error ?? "No se pudo generar el respaldo.");
+        return;
+      }
+
       await loadBackups();
     } catch (error) {
       setErrorMessage(
         error instanceof Error ? error.message : "Error al generar el respaldo",
       );
     } finally {
-      setIsGenerating(false);
+      if (montado.current) setIsGenerating(false);
     }
   }
 

--- a/frontend/src/features/respaldos/domain/backup.model.ts
+++ b/frontend/src/features/respaldos/domain/backup.model.ts
@@ -6,10 +6,27 @@ export interface Backup {
   fileSizeBytes: number;
 }
 
+export type BackupJobStatus = "Pendiente" | "EnProceso" | "Completado" | "Fallido";
+
+export interface BackupJob {
+  id: string;
+  status: BackupJobStatus;
+  fileName?: string;
+  error?: string;
+}
+
+/** Un trabajo terminado ya no cambia de estado: no tiene sentido seguir sondeando. */
+export function esEstadoFinal(status: BackupJobStatus): boolean {
+  return status === "Completado" || status === "Fallido";
+}
+
 // Mismo patron que aplica el backend en BackupService.OpenBackup. Se replica aqui
 // para no llegar a pedir al servidor un nombre que ya sabemos que va a rechazar.
 // No es una medida de seguridad: la autoritativa es la del servidor.
-const BACKUP_FILE_NAME = /^backup_\d{8}_\d{4}\.sql$/;
+// Seis digitos es el formato actual (HHmmss); cuatro es el anterior (HHmm), que se
+// sigue aceptando para que los respaldos ya generados se puedan descargar. El sufijo
+// opcional desambigua dos respaldos creados dentro del mismo segundo.
+const BACKUP_FILE_NAME = /^backup_\d{8}_(\d{6}|\d{4})(_\d+)?\.sql$/;
 
 export function isValidBackupFileName(fileName: string): boolean {
   return BACKUP_FILE_NAME.test(fileName);

--- a/frontend/src/features/respaldos/infrastructure/backup.repository.ts
+++ b/frontend/src/features/respaldos/infrastructure/backup.repository.ts
@@ -1,12 +1,13 @@
 import { backupService } from "@/services/backup.service";
 
-import { Backup, sortBackupsByDateDesc } from "../domain/backup.model";
+import { Backup, BackupJob, sortBackupsByDateDesc } from "../domain/backup.model";
 
 // Capa de infraestructura: traduce entre el servicio HTTP y el dominio.
 // La capa de aplicacion depende de este puerto, no de fetch.
 export interface BackupRepository {
   list(): Promise<Backup[]>;
-  generate(): Promise<Backup>;
+  generate(): Promise<BackupJob>;
+  getJob(jobId: string): Promise<BackupJob>;
   download(fileName: string): Promise<Blob>;
 }
 
@@ -16,8 +17,13 @@ export const httpBackupRepository: BackupRepository = {
     return sortBackupsByDateDesc(data);
   },
 
+  // Devuelve el trabajo encolado, no el archivo: el respaldo aun no existe.
   async generate() {
     return backupService.generateBackup();
+  },
+
+  async getJob(jobId: string) {
+    return backupService.getBackupJob(jobId);
   },
 
   async download(fileName: string) {

--- a/frontend/src/services/backup.service.ts
+++ b/frontend/src/services/backup.service.ts
@@ -14,6 +14,17 @@ export type BackupData = {
   fileSizeBytes: number;
 };
 
+/** Estados que devuelve el backend para un trabajo de respaldo. */
+export type BackupJobStatus = "Pendiente" | "EnProceso" | "Completado" | "Fallido";
+
+export type BackupJobData = {
+  id: string;
+  status: BackupJobStatus;
+  fileName?: string;
+  fileSizeBytes?: number;
+  error?: string;
+};
+
 export const backupService = {
   async listBackups(): Promise<BackupData[]> {
     const res = await fetch(`${apiUrl}/api/Admin/backups`, {
@@ -23,7 +34,9 @@ export const backupService = {
     return res.json();
   },
 
-  async generateBackup(): Promise<BackupData> {
+  // Devuelve un trabajo, no el archivo: el respaldo corre en segundo plano y hay
+  // que consultar su estado con getBackupJob hasta que termine.
+  async generateBackup(): Promise<BackupJobData> {
     const res = await fetch(`${apiUrl}/api/Admin/backup`, {
       method: "POST",
       headers: authHeaders(),
@@ -32,6 +45,14 @@ export const backupService = {
       const err = await res.json().catch(() => ({}));
       throw new Error(err.message ?? "Error al generar el respaldo");
     }
+    return res.json();
+  },
+
+  async getBackupJob(jobId: string): Promise<BackupJobData> {
+    const res = await fetch(`${apiUrl}/api/Admin/backup/jobs/${jobId}`, {
+      headers: authHeaders(),
+    });
+    if (!res.ok) throw new Error("No se pudo consultar el estado del respaldo");
     return res.json();
   },
 

--- a/frontend/tests/respaldos.spec.ts
+++ b/frontend/tests/respaldos.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect, Page } from '@playwright/test';
 
 const RESPALDOS_URL = 'http://localhost:3000/usuarios/respaldos';
+const JOB_ID = '11111111-2222-3333-4444-555555555555';
 
 const backupsFixture = [
-  { fileName: 'backup_20260813_1537.sql', createdAt: '2026-08-13T15:37:14Z', fileSizeBytes: 18651 },
-  { fileName: 'backup_20260812_0900.sql', createdAt: '2026-08-12T09:00:00Z', fileSizeBytes: 2048 },
+  { fileName: 'backup_20260813_153714.sql', createdAt: '2026-08-13T15:37:14Z', fileSizeBytes: 18651 },
+  { fileName: 'backup_20260812_090000.sql', createdAt: '2026-08-12T09:00:00Z', fileSizeBytes: 2048 },
 ];
 
 /** Sesion simulada: las paginas de administracion leen el token de localStorage. */
@@ -22,6 +23,31 @@ async function mockList(page: Page, body: unknown, status = 200) {
   });
 }
 
+/** El POST solo encola: responde 202 con un trabajo todavia sin terminar. */
+async function mockEncolar(page: Page, status = 202) {
+  await page.route('**/api/Admin/backup', async route => {
+    await route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: JOB_ID, status: 'Pendiente' }),
+    });
+  });
+}
+
+/** Devuelve los estados indicados, uno por consulta; repite el ultimo al agotarse. */
+async function mockEstadosDelTrabajo(page: Page, estados: unknown[]) {
+  let consulta = 0;
+  await page.route('**/api/Admin/backup/jobs/**', async route => {
+    const cuerpo = estados[Math.min(consulta, estados.length - 1)];
+    consulta++;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(cuerpo),
+    });
+  });
+}
+
 test.describe('Panel de respaldos', () => {
   test('muestra la lista de respaldos existentes', async ({ page }) => {
     await authenticate(page);
@@ -31,7 +57,7 @@ test.describe('Panel de respaldos', () => {
 
     await expect(page.getByTestId('backups-title')).toBeVisible();
     await expect(page.getByTestId('backup-row')).toHaveCount(2);
-    await expect(page.getByTestId('backup-filename').first()).toHaveText('backup_20260813_1537.sql');
+    await expect(page.getByTestId('backup-filename').first()).toHaveText('backup_20260813_153714.sql');
     await expect(page.getByTestId('backups-count')).toHaveText('2 archivos');
   });
 
@@ -65,23 +91,40 @@ test.describe('Panel de respaldos', () => {
     await expect(page.getByTestId('backups-persistence-warning')).toBeVisible();
   });
 
-  test('generar un respaldo refresca la lista', async ({ page }) => {
+  // ───────────────────────────────────────────────────────────────
+  // Flujo asincrono (issue #162)
+  // ───────────────────────────────────────────────────────────────
+
+  test('espera a que el trabajo termine antes de refrescar la lista', async ({ page }) => {
     await authenticate(page);
 
-    let listCalls = 0;
+    // El archivo NO existe hasta que el trabajo se reporta Completado. Sin esto la
+    // prueba pasaria tambien con el codigo defectuoso, que recargaba de inmediato:
+    // el listado devolveria el archivo aunque el servidor no lo hubiera escrito.
+    let trabajoTerminado = false;
+
     await page.route('**/api/Admin/backups', async route => {
       if (route.request().method() !== 'GET') return route.fallback();
-      listCalls += 1;
-      // La primera carga esta vacia; tras generar, la lista ya trae el archivo.
-      const body = listCalls === 1 ? [] : [backupsFixture[0]];
+      const body = trabajoTerminado ? [backupsFixture[0]] : [];
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
     });
 
-    await page.route('**/api/Admin/backup', async route => {
+    await mockEncolar(page);
+
+    let consultas = 0;
+    await page.route('**/api/Admin/backup/jobs/**', async route => {
+      consultas++;
+      // Sigue en proceso en la primera consulta; termina en la segunda.
+      const completado = consultas >= 2;
+      if (completado) trabajoTerminado = true;
       await route.fulfill({
-        status: 201,
+        status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(backupsFixture[0]),
+        body: JSON.stringify(
+          completado
+            ? { id: JOB_ID, status: 'Completado', fileName: backupsFixture[0].fileName }
+            : { id: JOB_ID, status: 'EnProceso' },
+        ),
       });
     });
 
@@ -90,11 +133,43 @@ test.describe('Panel de respaldos', () => {
 
     await page.getByTestId('generate-backup-button').click();
 
+    // Antes se recargaba nada mas recibir el 202, con el archivo aun sin existir.
     await expect(page.getByTestId('backup-row')).toHaveCount(1);
-    await expect(page.getByTestId('backup-filename')).toHaveText('backup_20260813_1537.sql');
+    await expect(page.getByTestId('backup-filename')).toHaveText(backupsFixture[0].fileName);
   });
 
-  test('muestra el error cuando la generacion falla', async ({ page }) => {
+  test('el boton sigue mostrando actividad mientras el trabajo no termina', async ({ page }) => {
+    await authenticate(page);
+    await mockList(page, []);
+    await mockEncolar(page);
+    // El trabajo nunca sale de EnProceso durante la comprobacion.
+    await mockEstadosDelTrabajo(page, [{ id: JOB_ID, status: 'EnProceso' }]);
+
+    await page.goto(RESPALDOS_URL);
+    await page.getByTestId('generate-backup-button').click();
+
+    // El sintoma reportado era que el indicador terminaba al instante, con el
+    // respaldo todavia ejecutandose en el servidor.
+    await page.waitForTimeout(2500);
+    await expect(page.getByTestId('generate-backup-button')).toBeDisabled();
+  });
+
+  test('muestra el motivo cuando el trabajo termina en Fallido', async ({ page }) => {
+    await authenticate(page);
+    await mockList(page, []);
+    await mockEncolar(page);
+    await mockEstadosDelTrabajo(page, [
+      { id: JOB_ID, status: 'Fallido', error: 'No se pudo generar el respaldo.' },
+    ]);
+
+    await page.goto(RESPALDOS_URL);
+    await page.getByTestId('generate-backup-button').click();
+
+    await expect(page.getByTestId('backups-error')).toBeVisible();
+    await expect(page.getByTestId('backups-error')).toContainText('No se pudo generar el respaldo');
+  });
+
+  test('muestra el error cuando el encolado falla', async ({ page }) => {
     await authenticate(page);
     await mockList(page, []);
 
@@ -122,12 +197,16 @@ test.describe('Panel de respaldos', () => {
     await expect(page.getByTestId('backups-error')).toBeVisible();
   });
 
+  // ───────────────────────────────────────────────────────────────
+  // Descarga
+  // ───────────────────────────────────────────────────────────────
+
   test('la descarga pide el archivo con cabecera Authorization', async ({ page }) => {
     await authenticate(page);
     await mockList(page, [backupsFixture[0]]);
 
     let authHeader: string | undefined;
-    await page.route('**/api/Admin/backups/backup_20260813_1537.sql', async route => {
+    await page.route(`**/api/Admin/backups/${backupsFixture[0].fileName}`, async route => {
       authHeader = route.request().headers()['authorization'];
       await route.fulfill({
         status: 200,
@@ -145,6 +224,26 @@ test.describe('Panel de respaldos', () => {
     // Lo que se verifica no es solo que descargue, sino que lleve el token:
     // un <a href> plano devolveria 401 porque el navegador no lo adjunta.
     expect(authHeader).toBe('Bearer fake-token');
-    expect(download.suggestedFilename()).toBe('backup_20260813_1537.sql');
+    expect(download.suggestedFilename()).toBe(backupsFixture[0].fileName);
+  });
+
+  test('acepta descargar respaldos con el formato de nombre anterior', async ({ page }) => {
+    // Los archivos creados antes del cambio a segundos tienen cuatro digitos.
+    // Si la lista blanca del dominio no los aceptara, dejarian de poder descargarse.
+    await authenticate(page);
+    const antiguo = { fileName: 'backup_20260813_2017.sql', createdAt: '2026-08-13T20:17:00Z', fileSizeBytes: 20480 };
+    await mockList(page, [antiguo]);
+
+    await page.route(`**/api/Admin/backups/${antiguo.fileName}`, async route => {
+      await route.fulfill({ status: 200, contentType: 'application/octet-stream', body: '-- antiguo' });
+    });
+
+    await page.goto(RESPALDOS_URL);
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByTestId('backup-download-button').click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe(antiguo.fileName);
   });
 });


### PR DESCRIPTION
## 📌 Resumen del Cambio

Generar un respaldo desde `/usuarios/respaldos` parecía no hacer nada: el indicador terminaba al instante, la lista se recargaba sin novedad y reintentar no producía archivos. De **71 peticiones al endpoint solo quedaron 4 archivos**.

Eran **dos defectos independientes** que se manifestaban juntos.

---

## 🔍 Tipo de Cambio realizado

- [x] 🐞 Corrección de error (`fix`)
- [ ] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [x] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

**Backend**
- `Services/BackupService.cs` — segundos en el nombre, sufijo de desambiguación, lista blanca ampliada
- `Tests/Unit/BackupServiceTests.cs`

**Frontend**
- `src/services/backup.service.ts` — tipo del trabajo y `getBackupJob`
- `src/features/respaldos/domain/backup.model.ts` — `BackupJob`, `esEstadoFinal`, lista blanca ampliada
- `src/features/respaldos/infrastructure/backup.repository.ts` — puerto `getJob`
- `src/features/respaldos/application/use-backups-controller.ts` — sondeo del trabajo
- `tests/respaldos.spec.ts`

---

## 🧪 ¿Cómo Probarlo?

```bash
dotnet run --project backend/SistemaServicios.API
cd frontend && npm run dev
```

En `/usuarios/respaldos` como administrador:

1. Pulsar **Generar respaldo**: el botón queda bloqueado mostrando *Generando…* **hasta que el respaldo termina de verdad**, no un instante.
2. Al terminar, la lista se refresca con el archivo nuevo.
3. Pulsar varias veces seguidas: cada respaldo produce **un archivo distinto**, incluso dentro del mismo segundo.
4. Los respaldos anteriores (nombres de 4 dígitos, como `backup_20260813_2017.sql`) siguen listándose y descargándose.

```bash
cd backend && dotnet test
cd frontend && npx playwright test tests/respaldos.spec.ts
```

---

## ✅ Checklist

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [x] Se han actualizado o agregado pruebas
- [x] La documentación se actualizó si fue necesario
- [x] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Closes #162

### Defecto 1 — Desajuste de contrato entre #158 y #126

La pantalla de [#158](https://github.com/vidanj/Gestion-Servicios-Profesionales/issues/158) se escribió cuando `POST /api/Admin/backup` devolvía **201 con el archivo ya generado**. [#126](https://github.com/vidanj/Gestion-Servicios-Profesionales/issues/126) lo cambió a **202 con un trabajo en segundo plano** y el frontend nunca se adaptó:

```ts
await repository.generate();   // ahora retorna 202 al instante, trabajo "Pendiente"
await loadBackups();           // recarga ANTES de que el respaldo exista
```

Los tres síntomas salen de ahí uno a uno: el indicador terminaba al recibir el 202 y no al acabar `pg_dump`; la lista se pedía antes de que el archivo estuviera escrito; y al reintentar, el guardia de concurrencia devolvía *el mismo* trabajo en curso —comportamiento correcto del backend— que el frontend interpretaba como un encargo nuevo.

Ahora la pantalla sondea `GET /api/Admin/backup/jobs/{id}` hasta `Completado` o `Fallido`, mantiene el botón bloqueado durante toda la espera, recarga la lista una sola vez al terminar y muestra el motivo si falla. El sondeo tiene tope de intentos para no quedar girando si el servidor deja de responder, y se detiene si la pantalla se desmonta.

### Defecto 2 — Nombres que colisionaban por minuto

```csharp
var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmm", ...);
```

**Dos respaldos del mismo minuto compartían nombre y el segundo sobrescribía al primero sin aviso.** Los cuatro archivos observados eran de las 20:14, 20:15, 20:16 y 20:17: de cada minuto solo sobrevivía el último. Es un defecto **anterior a #126**, heredado del código original, que también afecta a quien use la API directamente.

**Los segundos no bastaban.** Una prueba lo demostró: dos llamadas consecutivas caen dentro del mismo segundo y seguían colisionando. Se añade un sufijo de desambiguación cuando el nombre ya existe, lo que convierte la unicidad en una garantía y no en una probabilidad.

### Compatibilidad con los respaldos ya generados

La lista blanca pasa a `^backup_\d{8}_(\d{6}|\d{4})(_\d+)?\.sql$`. **Sin la tolerancia a los 4 dígitos, los respaldos que ya existen habrían desaparecido de la lista y no se habrían podido descargar** — el usuario habría perdido acceso a ellos sin ningún aviso. Se actualiza en los dos sitios donde vive la regla: `BackupService.OpenBackup` y el dominio del frontend.

### Las pruebas de regresión se verificaron de verdad

Las dos specs del flujo asíncrono se comprobaron **revirtiendo temporalmente el sondeo**: ambas fallan con el código defectuoso y pasan con el arreglo.

Merece mención que **la primera versión de una de ellas no servía**. El mock devolvía el archivo en la segunda llamada al listado sin comprobar el estado del trabajo, así que habría pasado igual con el bug presente. Se rehízo para que el listado devuelva el archivo solo después de que el trabajo se reporte `Completado`, que es lo que ocurre en la realidad.

### Cómo se llegó aquí

El desajuste entre #126 y #158 **estaba previsto y anotado** en el cuerpo de la PR de #126: *"cuando se integre habrá que adaptarla al flujo asíncrono"*. Se dejó como nota en vez de bloquear el merge o corregirlo en el momento, y llegó roto a `dev`. Un cambio de contrato en un endpoint debería arrastrar a sus consumidores en la misma PR, o bloquearse hasta que exista el issue que los adapte.

Refuerza además el valor de [#129](https://github.com/vidanj/Gestion-Servicios-Profesionales/issues/129): sin E2E de frontend en CI, nada detectó que la pantalla había dejado de funcionar.

### Verificación

Backend **263 pruebas** y frontend **105**, sin fallos. CSharpier y los analizadores limpios con `TreatWarningsAsErrors`.
