### PR TITLE
feat(backend): añade sondas de liveness y readiness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,10 @@ RUN apt-get update \
         > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client-18 \
-    && apt-get purge -y --auto-remove curl gnupg \
+    && apt-get purge -y --auto-remove gnupg \
     && rm -rf /var/lib/apt/lists/*
+# curl se conserva a proposito: lo necesita la instruccion HEALTHCHECK de mas abajo.
+# La imagen base no trae ningun cliente HTTP.
 
 # Destino de los respaldos. Fuera de /app para poder montarlo como volumen:
 # sin un montaje explicito el .sql muere con el contenedor (ver issue #126).
@@ -60,5 +62,12 @@ RUN chmod +x entrypoint.sh efbundle
 # Sin seccion Kestrel en appsettings.json, ASPNETCORE_URLS controla el binding.
 ENV ASPNETCORE_URLS=http://+:10000
 EXPOSE 10000
+
+# Sonda de readiness: la instancia solo se considera sana si ademas alcanza la base.
+# start-period cubre el tiempo que entrypoint.sh dedica a aplicar migraciones con
+# efbundle antes de que Kestrel empiece a escuchar; sin ese margen, el contenedor se
+# marcaria como enfermo durante un arranque perfectamente normal.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD curl --fail --silent --show-error http://localhost:10000/health/ready || exit 1
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ dotnet run --project backend/SistemaServicios.API
 #http://localhost:5000/openapi/v1.json
 ```
  
+## 🩺 Sondas de Disponibilidad
+
+Dos endpoints anónimos, pensados para orquestadores y balanceadores. Son distintos a propósito: uno responde *"no me reinicies"* y el otro *"puedo recibir tráfico"*.
+
+| Ruta | Comprueba | Respuestas |
+|------|-----------|-----------|
+| `GET /health/live` | Solo que el proceso esté vivo. **No consulta dependencias.** | `200 Healthy` mientras el proceso responda |
+| `GET /health/ready` | Además, que PostgreSQL esté alcanzable (timeout 3 s) | `200 Healthy` / `503 Unhealthy` |
+
+```bash
+curl -i http://localhost:5000/health/live
+curl -i http://localhost:5000/health/ready
+```
+
+**Por qué liveness no mira la base de datos:** si lo hiciera, una caída de PostgreSQL haría que el orquestador reiniciara un proceso perfectamente sano, una y otra vez, sin arreglar nada. Con la separación, una base caída saca la instancia de rotación (`503` en readiness) pero no provoca reinicios.
+
+La respuesta es JSON con el estado y la duración de cada comprobación. **No incluye la cadena de conexión, el host de la base ni trazas de excepción**: los endpoints son anónimos y el detalle va al log.
+
+El `Dockerfile` declara un `HEALTHCHECK` contra `/health/ready` con `start-period` de 60 s, margen que cubre el tiempo que `entrypoint.sh` dedica a aplicar migraciones antes de que Kestrel empiece a escuchar.
+
 ## 📊 Índices de Base de Datos — Notas de Diseño
 
 ### `Users.Status` (índice parcial)

--- a/backend/SistemaServicios.API/Extensions/ApplicationServiceExtensions.cs
+++ b/backend/SistemaServicios.API/Extensions/ApplicationServiceExtensions.cs
@@ -78,6 +78,11 @@ public static class ApplicationServiceExtensions
 
         services.AddScoped<ITokenService, TokenService>();
         services.AddScoped<IAuthService, AuthService>();
+
+        // Sondas: la etiqueta "ready" separa lo que decide si la instancia puede recibir
+        // tráfico de lo que solo confirma que el proceso sigue vivo.
+        _ = services.AddHealthChecks().AddCheck<DatabaseHealthCheck>("postgresql", tags: ["ready"]);
+
         services.AddScoped<IProcessRunner, ProcessRunner>();
         services.AddScoped<IBackupService, BackupService>();
 

--- a/backend/SistemaServicios.API/Extensions/HealthCheckResponseWriter.cs
+++ b/backend/SistemaServicios.API/Extensions/HealthCheckResponseWriter.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace SistemaServicios.API.Extensions;
+
+/// <summary>
+/// Escribe el resultado de las sondas como JSON.
+/// Deliberadamente no serializa la excepción ni los datos del origen: la respuesta es
+/// anónima y filtrar la cadena de conexión o el host de la base ahí sería una fuga.
+/// El detalle queda en el log.
+/// </summary>
+public static class HealthCheckResponseWriter
+{
+    public static Task WriteAsync(HttpContext context, HealthReport report)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(report);
+
+        context.Response.ContentType = "application/json; charset=utf-8";
+
+        var payload = new
+        {
+            status = report.Status.ToString(),
+            totalDurationMs = Math.Round(report.TotalDuration.TotalMilliseconds),
+            checks = report
+                .Entries.Select(entry => new
+                {
+                    name = entry.Key,
+                    status = entry.Value.Status.ToString(),
+                    durationMs = Math.Round(entry.Value.Duration.TotalMilliseconds),
+                    description = entry.Value.Description,
+                })
+                .ToList(),
+        };
+
+        return context.Response.WriteAsync(JsonSerializer.Serialize(payload));
+    }
+}

--- a/backend/SistemaServicios.API/Program.cs
+++ b/backend/SistemaServicios.API/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using SistemaServicios.API.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -33,11 +34,40 @@ app.Use(
     }
 );
 
-app.UseHttpsRedirection();
+// Las sondas quedan fuera de la redirección a HTTPS. Hoy no redirige porque no hay
+// puerto HTTPS configurado, pero si alguien lo añadiera, la sonda del contenedor
+// recibiría un 307 y el contenedor pasaría a considerarse enfermo sin estarlo.
+app.UseWhen(
+    context => !context.Request.Path.StartsWithSegments("/health"),
+    branch => branch.UseHttpsRedirection()
+);
+
 app.UseStaticFiles();
 app.UseCors("FrontendPolicy");
 app.UseAuthentication();
 app.UseAuthorization();
+
+// Liveness: responde mientras el proceso viva. No consulta dependencias a propósito;
+// si lo hiciera, una base caída provocaría reinicios en bucle de un proceso sano.
+app.MapHealthChecks(
+    "/health/live",
+    new HealthCheckOptions
+    {
+        Predicate = _ => false,
+        ResponseWriter = HealthCheckResponseWriter.WriteAsync,
+    }
+);
+
+// Readiness: solo está listo si además puede alcanzar la base de datos.
+app.MapHealthChecks(
+    "/health/ready",
+    new HealthCheckOptions
+    {
+        Predicate = check => check.Tags.Contains("ready"),
+        ResponseWriter = HealthCheckResponseWriter.WriteAsync,
+    }
+);
+
 app.MapControllers();
 
 app.Run();

--- a/backend/SistemaServicios.API/Services/DatabaseHealthCheck.cs
+++ b/backend/SistemaServicios.API/Services/DatabaseHealthCheck.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using SistemaServicios.API.Data;
+
+namespace SistemaServicios.API.Services;
+
+/// <summary>
+/// Comprueba que PostgreSQL está alcanzable. Es la diferencia entre "el proceso vive"
+/// y "el proceso puede atender peticiones": sin esta comprobación, una instancia con la
+/// base caída seguiría recibiendo tráfico y fallando petición a petición.
+/// </summary>
+public class DatabaseHealthCheck : IHealthCheck
+{
+    // Sin tope, una base que no responde dejaría la sonda colgada y el orquestador
+    // interpretaría el tiempo de espera agotado en lugar de un estado claro.
+    private static readonly TimeSpan TiempoMaximo = TimeSpan.FromSeconds(3);
+
+    private readonly AppDbContext _context;
+
+    public DatabaseHealthCheck(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default
+    )
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(TiempoMaximo);
+
+        try
+        {
+            return await _context.Database.CanConnectAsync(cts.Token)
+                ? HealthCheckResult.Healthy("La base de datos responde.")
+                : HealthCheckResult.Unhealthy("La base de datos no acepta conexiones.");
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return HealthCheckResult.Unhealthy(
+                "La comprobación de la base de datos agotó el tiempo de espera."
+            );
+        }
+        catch (Exception ex)
+        {
+            // Una sonda nunca debe propagar: hacerlo convertiría un fallo de dependencia
+            // en un 500 sin diagnóstico. La excepción viaja al log, no a la respuesta.
+            return HealthCheckResult.Unhealthy("La base de datos no está disponible.", ex);
+        }
+    }
+}

--- a/backend/SistemaServicios.Tests/Integration/HealthChecksTests.cs
+++ b/backend/SistemaServicios.Tests/Integration/HealthChecksTests.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace SistemaServicios.Tests.Integration;
+
+/// <summary>
+/// Sonda siempre fallida, para simular la base de datos caída sin tener que apagarla.
+/// </summary>
+internal sealed class SondaCaida : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default
+    ) => Task.FromResult(HealthCheckResult.Unhealthy("La base de datos no está disponible."));
+}
+
+/// <summary>
+/// Factory que sustituye la comprobación de base de datos por una que siempre falla.
+/// </summary>
+public class UnhealthyWebApplicationFactory : CustomWebApplicationFactory
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+
+        _ = builder.ConfigureServices(services =>
+        {
+            // Se retira el registro real y se deja solo la sonda que falla, conservando
+            // la etiqueta "ready" para que /health/ready siga evaluándola.
+            var registros = services
+                .Where(d => d.ServiceType == typeof(HealthCheckService))
+                .ToList();
+            foreach (var registro in registros)
+            {
+                _ = services.Remove(registro);
+            }
+
+            _ = services.Configure<HealthCheckServiceOptions>(options =>
+            {
+                options.Registrations.Clear();
+                options.Registrations.Add(
+                    new HealthCheckRegistration(
+                        "postgresql",
+                        new SondaCaida(),
+                        HealthStatus.Unhealthy,
+                        ["ready"]
+                    )
+                );
+            });
+
+            _ = services.AddHealthChecks();
+        });
+    }
+}
+
+/// <summary>
+/// Pruebas de las sondas de disponibilidad.
+/// </summary>
+public class HealthChecksTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public HealthChecksTests(CustomWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task LiveRespondeSinToken()
+    {
+        // Arrange & Act: la sonda debe ser accesible sin autenticación; un orquestador
+        // no tiene credenciales de la aplicación.
+        var response = await _client.GetAsync(new Uri("/health/live", UriKind.Relative));
+
+        // Assert
+        _ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task LiveNoConsultaDependencias()
+    {
+        // Act
+        var response = await _client.GetAsync(new Uri("/health/live", UriKind.Relative));
+        var contenido = await response.Content.ReadAsStringAsync();
+
+        // Assert: liveness no evalúa ninguna comprobación. Si evaluara la base, una
+        // caída de PostgreSQL provocaría reinicios en bucle de un proceso sano.
+        _ = contenido.Should().Contain("\"status\":\"Healthy\"");
+        _ = contenido.Should().Contain("\"checks\":[]");
+    }
+
+    [Fact]
+    public async Task ReadyRespondeSinToken()
+    {
+        // Act
+        var response = await _client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+
+        // Assert
+        _ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ReadyIncluyeLaComprobacionDeBaseDeDatos()
+    {
+        // Act
+        var response = await _client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+        var contenido = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        _ = contenido.Should().Contain("postgresql");
+        _ = contenido.Should().Contain("\"status\":\"Healthy\"");
+    }
+
+    [Fact]
+    public async Task ReadyNoFiltraConfiguracionSensible()
+    {
+        // Act
+        var response = await _client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+        var contenido = await response.Content.ReadAsStringAsync();
+
+        // Assert: la respuesta es anónima, así que no puede revelar cómo se conecta
+        // la aplicación ni exponer trazas de excepción.
+        _ = contenido.Should().NotContain("Password");
+        _ = contenido.Should().NotContain("Host=");
+        _ = contenido.Should().NotContain("Username");
+        _ = contenido.Should().NotContain("Exception");
+        _ = contenido.Should().NotContain("at Npgsql");
+    }
+
+    [Fact]
+    public async Task ReadyDevuelveLaDuracionDeCadaComprobacion()
+    {
+        // Act
+        var response = await _client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+        var contenido = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        _ = contenido.Should().Contain("totalDurationMs");
+        _ = contenido.Should().Contain("durationMs");
+    }
+}
+
+/// <summary>
+/// Comportamiento de las sondas con la base de datos inalcanzable.
+/// </summary>
+public class HealthChecksConBaseCaidaTests : IClassFixture<UnhealthyWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public HealthChecksConBaseCaidaTests(UnhealthyWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ReadyDevuelve503CuandoLaBaseNoResponde()
+    {
+        // Act
+        var response = await _client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+
+        // Assert: es la señal que permite sacar la instancia de rotación en lugar de
+        // seguir enviándole tráfico que va a fallar.
+        _ = response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task LiveSigueRespondiendo200AunqueLaBaseEsteCaida()
+    {
+        // Act
+        var response = await _client.GetAsync(new Uri("/health/live", UriKind.Relative));
+
+        // Assert: el proceso está sano; reiniciarlo no arreglaría la base y solo
+        // provocaría un bucle de reinicios.
+        _ = response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ReadyConBaseCaidaTampocoFiltraDetalleInterno()
+    {
+        // Act
+        var response = await _client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+        var contenido = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        _ = contenido.Should().Contain("Unhealthy");
+        _ = contenido.Should().NotContain("Exception");
+        _ = contenido.Should().NotContain("Host=");
+    }
+}


### PR DESCRIPTION
## 📌 Resumen del Cambio

La aplicación no publicaba ningún indicador de salud. Nada permitía distinguir **"arrancando"** de **"roto"**: durante el arranque, `entrypoint.sh` aplica las migraciones antes de que Kestrel escuche, y un balanceador enviaría tráfico a un contenedor que todavía no puede atenderlo. Con la base caída, el síntoma era un 500 por petición en vez de una instancia retirada de rotación.

Se añaden `GET /health/live` y `GET /health/ready`, anónimos, más el `HEALTHCHECK` del `Dockerfile`.

---

## 🔍 Tipo de Cambio realizado

- [ ] 🐞 Corrección de error (`fix`)
- [x] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [x] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [x] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

- `Services/DatabaseHealthCheck.cs` — nuevo
- `Extensions/HealthCheckResponseWriter.cs` — nuevo
- `Extensions/ApplicationServiceExtensions.cs` — registro con etiqueta `ready`
- `Program.cs` — mapeo de las sondas y exclusión de la redirección a HTTPS
- `Dockerfile` — `HEALTHCHECK` y `curl` conservado
- `README.md` — sección de sondas
- `Tests/Integration/HealthChecksTests.cs` — nuevo

---

## 🧪 ¿Cómo Probarlo?

```bash
dotnet run --project backend/SistemaServicios.API

curl -i http://localhost:5000/health/live    # 200, checks vacío
curl -i http://localhost:5000/health/ready   # 200 con la base arriba
```

Apagando PostgreSQL, `/health/ready` pasa a **503** y `/health/live` sigue en **200**.

En contenedor:

```bash
docker build -t gsp-api .
docker run -d --name gsp -p 10000:10000 -e DB_HOST=... gsp-api
docker inspect --format '{{.State.Health.Status}}' gsp
```

```bash
cd backend && dotnet test
```

---

## ✅ Checklist

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [x] Se han actualizado o agregado pruebas
- [x] La documentación se actualizó si fue necesario
- [x] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Closes #123

### Por qué liveness no consulta la base de datos

Es la decisión de diseño central. Si `/health/live` mirara PostgreSQL, una caída de la base haría que el orquestador **reiniciara en bucle un proceso perfectamente sano**, sin arreglar nada. Con la separación, una base caída retira la instancia de rotación (`503` en readiness) pero no provoca reinicios.

### Sin dependencia nueva

Lo habitual sería `AddDbContextCheck<AppDbContext>()`, que exige el paquete `HealthChecks.EntityFrameworkCore`. Un `IHealthCheck` propio con `CanConnectAsync` hace lo mismo y permite fijar el tope de 3 s. **Sin ese tope**, una base que no responde dejaría la sonda colgada y el orquestador vería un tiempo de espera agotado en lugar de un estado claro.

### La respuesta no filtra configuración

El escritor **no serializa la excepción ni los datos del origen**. Los endpoints son anónimos: exponer ahí la cadena de conexión o el host de la base sería una fuga. El detalle va al log. Hay pruebas que verifican que la respuesta no contiene `Host=`, `Password`, `Username`, `Exception` ni trazas de Npgsql, tanto con la base sana como caída.

### Las sondas quedan fuera de la redirección a HTTPS

Hoy `UseHttpsRedirection` no redirige porque no hay puerto HTTPS configurado. Pero si alguien lo añadiera, la sonda del contenedor recibiría un **307** y el contenedor pasaría a considerarse enfermo sin estarlo. Se envuelve con `UseWhen` para que `/health` nunca pase por ahí.

### `curl` se conserva en la imagen

En [#133](https://github.com/vidanj/Gestion-Servicios-Profesionales/issues/133) se instalaba para el repositorio PGDG y se purgaba después. **La imagen base no trae ningún cliente HTTP**, y sin uno el `HEALTHCHECK` no puede ejecutarse. Son ~5 MB sobre 615 (615 → 620 MB).

El `start-period` de 60 s cubre el tiempo que `entrypoint.sh` dedica al `efbundle`; sin ese margen el contenedor se marcaría como enfermo durante un arranque normal.

### Verificación contra contenedores reales

| Escenario | Resultado |
|---|---|
| Base accesible, `docker inspect` | `healthy` |
| Base accesible, salida de la sonda | `{"status":"Healthy","checks":[{"name":"postgresql",...}]}` |
| Base inexistente, `/health/ready` | **503** con `"status":"Unhealthy"` |
| Base inexistente, `/health/live` | **200** — el proceso sigue sano |
| Base inexistente, comando del `HEALTHCHECK` | `curl: (22)` → **exit 22** |

Sobre el último punto: no esperé a que Docker marcara el contenedor como `unhealthy`, porque con `start-period=60s`, `interval=30s` y `retries=3` tarda unos 150 s. En su lugar verifiqué que **el comando exacto de la sonda sale con código distinto de cero**, que es lo que Docker evalúa.

### Verificación

Suite completa: **272 pruebas, 0 fallos** (eran 263), de las cuales 9 son nuevas de las sondas. CSharpier y los analizadores limpios con `TreatWarningsAsErrors`.

### Relación con el backlog

Desbloquea [#131](https://github.com/vidanj/Gestion-Servicios-Profesionales/issues/131), que lo tiene como prerrequisito duro: un pipeline que despliega sin poder comprobar la salud automatiza el error en lugar de prevenirlo. También es la señal que necesita [#128](https://github.com/vidanj/Gestion-Servicios-Profesionales/issues/128) para decidir a qué instancias enviar tráfico.
