### PR TITLE
chore(backend): resuelve la dirección real del cliente detrás del proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,16 @@ ALLOWED_ORIGINS=http://localhost:3000
 
 NEXT_PUBLIC_ALLOWED_PATH=http://localhost:5000
 
+# Proxies de confianza delante de la API (Cloudflare + edge de Render = 2).
+# Es lo que impide que un cliente suplante su direccion anteponiendo X-Forwarded-For:
+# solo se consideran las N entradas mas a la derecha. Un valor mayor que los saltos
+# reales haria confiar en datos que controla quien llama.
+FORWARDED_LIMIT=2
+
+# Redes CIDR del proxy, separadas por comas. Vacio en plataformas gestionadas, donde
+# no se pueden enumerar; en ese caso la defensa es FORWARDED_LIMIT.
+FORWARDED_NETWORKS=
+
 # Almacenamiento de archivos subidos (avatares).
 # Sin definir o con cualquier otro valor: se guardan en la base de datos, que es
 # lo que permite que sobrevivan a un despliegue y sean visibles desde cualquier

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,11 @@
 # "exec ./entrypoint.sh: no such file or directory".
 *.sh text eol=lf
 
+# Configuracion que consumen contenedores Linux: mismo criterio que los scripts,
+# para que un checkout en Windows no introduzca CRLF donde no se espera.
+*.conf text eol=lf
+docker-compose.yml text eol=lf
+
 *.cs text eol=lf
 *.csproj text eol=lf
 *.sln text eol=lf

--- a/README.md
+++ b/README.md
@@ -96,6 +96,53 @@ La respuesta es JSON con el estado y la duración de cada comprobación. **No in
 
 El `Dockerfile` declara un `HEALTHCHECK` contra `/health/ready` con `start-period` de 60 s, margen que cubre el tiempo que `entrypoint.sh` dedica a aplicar migraciones antes de que Kestrel empiece a escuchar.
 
+## 🔀 Proxy Inverso y Dirección Real del Cliente
+
+En producción hay **dos proxies** delante de la API: Cloudflare y el edge de Render. Sin configuración, `HttpContext.Connection.RemoteIpAddress` sería la del proxy, no la del usuario.
+
+| Variable | Por defecto | Qué hace |
+|----------|-------------|----------|
+| `FORWARDED_LIMIT` | `2` | Cuántos proxies de confianza hay delante |
+| `FORWARDED_NETWORKS` | *(vacío)* | Redes CIDR del proxy, separadas por comas |
+
+### Por qué `FORWARDED_LIMIT` es lo que protege
+
+`X-Forwarded-For` se **anexa**, no se reemplaza: un cliente puede enviar una dirección inventada y los proxies añadirán las suyas *a la derecha*. El middleware toma las `N` entradas más a la derecha y descarta el resto.
+
+```
+Cliente envía:   X-Forwarded-For: 9.9.9.9
+NGINX anexa:     X-Forwarded-For: 9.9.9.9, 203.0.113.7
+Con LIMIT=1  ->  dirección resuelta: 203.0.113.7   (la falsificada se descarta)
+```
+
+**Un valor mayor que los saltos reales hace confiar en entradas que controla quien llama.** Uno menor deja la dirección del proxy en lugar de la del cliente.
+
+### Cómo determinar el valor correcto
+
+Subir el nivel del middleware de diagnóstico a `Debug` y leer la cadena tal como llega:
+
+```
+Logging__LogLevel__SistemaServicios.API.Middleware=Debug
+```
+
+```
+X-Forwarded-For recibido: 9.9.9.9, 172.18.0.1 | dirección resuelta: 172.18.0.1
+```
+
+`FORWARDED_LIMIT` debe ser el número de entradas que añaden los proxies de confianza, contando desde la derecha.
+
+### Verificarlo en local
+
+`docker-compose.yml` levanta NGINX delante de la API, con la API **sin publicar al exterior**, igual que en producción:
+
+```bash
+docker compose up --build
+curl -s http://localhost:8080/health/ready
+curl -s -H "X-Forwarded-For: 9.9.9.9" http://localhost:8080/health/ready
+```
+
+En producción el proxy lo pone Render; este compose sirve para verificar el comportamiento y como base si algún día se autoaloja.
+
 ## 📊 Índices de Base de Datos — Notas de Diseño
 
 ### `Users.Status` (índice parcial)

--- a/backend/SistemaServicios.API/Extensions/ApplicationServiceExtensions.cs
+++ b/backend/SistemaServicios.API/Extensions/ApplicationServiceExtensions.cs
@@ -79,6 +79,18 @@ public static class ApplicationServiceExtensions
         services.AddScoped<ITokenService, TokenService>();
         services.AddScoped<IAuthService, AuthService>();
 
+        // Cabeceras reenviadas: sin esto, detrás de un proxy la dirección del cliente
+        // es siempre la del proxy. Hoy nada la registra, pero el limitador de intentos
+        // del tramo de blindaje contaría todos los intentos contra una sola dirección
+        // y bloquearía a los usuarios legítimos.
+        services.Configure<Microsoft.AspNetCore.Builder.ForwardedHeadersOptions>(options =>
+            ForwardedHeadersConfiguration.Configure(
+                options,
+                Environment.GetEnvironmentVariable("FORWARDED_LIMIT"),
+                Environment.GetEnvironmentVariable("FORWARDED_NETWORKS")
+            )
+        );
+
         // Sondas: la etiqueta "ready" separa lo que decide si la instancia puede recibir
         // tráfico de lo que solo confirma que el proceso sigue vivo.
         _ = services.AddHealthChecks().AddCheck<DatabaseHealthCheck>("postgresql", tags: ["ready"]);

--- a/backend/SistemaServicios.API/Extensions/ForwardedHeadersConfiguration.cs
+++ b/backend/SistemaServicios.API/Extensions/ForwardedHeadersConfiguration.cs
@@ -1,0 +1,96 @@
+using System.Globalization;
+using System.Net;
+using Microsoft.AspNetCore.HttpOverrides;
+using IPNetwork = Microsoft.AspNetCore.HttpOverrides.IPNetwork;
+
+namespace SistemaServicios.API.Extensions;
+
+/// <summary>
+/// Configuración del middleware de cabeceras reenviadas.
+/// Vive aparte para que las pruebas ejerciten exactamente la misma configuración que
+/// usa la aplicación, y no una copia que puede divergir sin que nadie lo note.
+/// </summary>
+public static class ForwardedHeadersConfiguration
+{
+    /// <summary>
+    /// Número de proxies de confianza por defecto: Cloudflare y el edge de Render.
+    /// El valor por defecto del framework es 1, que con esta topología devolvería la
+    /// dirección de Cloudflare en lugar de la del cliente.
+    /// </summary>
+    public const int DefaultForwardLimit = 2;
+
+    public static void Configure(
+        ForwardedHeadersOptions options,
+        string? forwardLimitRaw,
+        string? knownNetworksRaw
+    )
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.ForwardedHeaders =
+            ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+
+        // ForwardLimit es la defensa real: el middleware toma las N entradas más a la
+        // derecha de X-Forwarded-For y descarta las de la izquierda, que son las que un
+        // cliente puede anteponer. Un valor mayor que los saltos reales empezaría a
+        // confiar en datos que controla quien llama.
+        options.ForwardLimit = ParseForwardLimit(forwardLimitRaw);
+
+        // En una plataforma gestionada no se pueden enumerar las direcciones del proxy,
+        // y con las listas por defecto (solo loopback) el middleware no haría nada.
+        // Se vacían a propósito; quien pueda enumerarlas las aporta por configuración.
+        options.KnownNetworks.Clear();
+        options.KnownProxies.Clear();
+
+        foreach (var network in ParseKnownNetworks(knownNetworksRaw))
+        {
+            options.KnownNetworks.Add(network);
+        }
+    }
+
+    private static int ParseForwardLimit(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return DefaultForwardLimit;
+        }
+
+        // Un valor inválido no debe degradar en silencio a "confiar en todo".
+        return
+            int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+            && value > 0
+            ? value
+            : DefaultForwardLimit;
+    }
+
+    private static IEnumerable<IPNetwork> ParseKnownNetworks(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            yield break;
+        }
+
+        foreach (
+            var entry in raw.Split(
+                ',',
+                StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+            )
+        )
+        {
+            var partes = entry.Split('/');
+            if (
+                partes.Length == 2
+                && IPAddress.TryParse(partes[0], out var direccion)
+                && int.TryParse(
+                    partes[1],
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var prefijo
+                )
+            )
+            {
+                yield return new IPNetwork(direccion, prefijo);
+            }
+        }
+    }
+}

--- a/backend/SistemaServicios.API/Middleware/ForwardedHeadersDiagnostics.cs
+++ b/backend/SistemaServicios.API/Middleware/ForwardedHeadersDiagnostics.cs
@@ -1,0 +1,55 @@
+namespace SistemaServicios.API.Middleware;
+
+/// <summary>
+/// Registra la cadena de X-Forwarded-For recibida y la dirección que el middleware
+/// resolvió a partir de ella. Solo en nivel Debug: existe para poder confirmar el
+/// ForwardLimit correcto contra el despliegue real, que es la única forma de saber
+/// cuántos saltos tiene la cadena de verdad.
+/// </summary>
+public partial class ForwardedHeadersDiagnostics
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ForwardedHeadersDiagnostics> _logger;
+
+    public ForwardedHeadersDiagnostics(
+        RequestDelegate next,
+        ILogger<ForwardedHeadersDiagnostics> logger
+    )
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        // La comprobación evita trabajo en producción, donde el nivel habitual deja
+        // este registro apagado.
+        if (!_logger.IsEnabled(LogLevel.Debug))
+        {
+            await _next(context);
+            return;
+        }
+
+        // La cadena se captura ANTES de que UseForwardedHeaders la procese: ese
+        // middleware consume las entradas que aplica y deja solo el resto. Registrar
+        // la cadena ya recortada haría creer que llegaron menos saltos de los reales,
+        // que es justo el dato que se quiere medir aquí.
+        var cadenaOriginal = context.Request.Headers["X-Forwarded-For"].ToString();
+
+        await _next(context);
+
+        LogCadenaRecibida(
+            string.IsNullOrEmpty(cadenaOriginal) ? "(sin cabecera)" : cadenaOriginal,
+            context.Connection.RemoteIpAddress?.ToString() ?? "(sin dirección)"
+        );
+    }
+
+    [LoggerMessage(
+        EventId = 3000,
+        Level = LogLevel.Debug,
+        Message = "X-Forwarded-For recibido: {Cadena} | dirección resuelta: {Resuelta}"
+    )]
+    private partial void LogCadenaRecibida(string cadena, string resuelta);
+}

--- a/backend/SistemaServicios.API/Program.cs
+++ b/backend/SistemaServicios.API/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using SistemaServicios.API.Extensions;
+using SistemaServicios.API.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,6 +15,14 @@ builder.Services.AddOpenApi();
 var app = builder.Build();
 
 // --- 3. PIPELINE ---
+
+// Primero de todo: el resto del pipeline debe ver ya la dirección real del cliente.
+// Registrado más abajo, la autenticación y cualquier limitación por dirección
+// seguirían viendo la del proxy.
+// El diagnóstico va delante para ver la cadena tal como llega, antes de que
+// UseForwardedHeaders consuma las entradas que aplica.
+app.UseMiddleware<ForwardedHeadersDiagnostics>();
+app.UseForwardedHeaders();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();

--- a/backend/SistemaServicios.Tests/Integration/ForwardedHeadersTests.cs
+++ b/backend/SistemaServicios.Tests/Integration/ForwardedHeadersTests.cs
@@ -1,0 +1,232 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using SistemaServicios.API.Extensions;
+using Xunit;
+
+namespace SistemaServicios.Tests.Integration;
+
+/// <summary>
+/// Pruebas del middleware de cabeceras reenviadas.
+/// Usan la misma configuración que aplica la API (ForwardedHeadersConfiguration), no
+/// una copia: si esa configuración cambia, estas pruebas lo reflejan.
+/// </summary>
+public class ForwardedHeadersTests
+{
+    /// <summary>
+    /// Host mínimo con el middleware configurado y un terminal que devuelve la
+    /// dirección resuelta. Evita añadir a la API un endpoint de diagnóstico.
+    /// </summary>
+    private static async Task<IHost> CrearHost(string? limite, string? redes = null)
+    {
+        var host = await new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                _ = webBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                        services.Configure<ForwardedHeadersOptions>(options =>
+                            ForwardedHeadersConfiguration.Configure(options, limite, redes)
+                        )
+                    )
+                    .Configure(app =>
+                    {
+                        app.UseForwardedHeaders();
+                        app.Run(async context =>
+                        {
+                            var direccion =
+                                context.Connection.RemoteIpAddress?.ToString() ?? "(nula)";
+                            await context.Response.WriteAsync(
+                                $"{direccion}|{context.Request.Scheme}"
+                            );
+                        });
+                    });
+            })
+            .StartAsync();
+
+        return host;
+    }
+
+    private static async Task<string> Pedir(
+        IHost host,
+        string? forwardedFor,
+        string? forwardedProto = null
+    )
+    {
+        var client = host.GetTestClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, "/");
+
+        if (forwardedFor is not null)
+        {
+            request.Headers.Add("X-Forwarded-For", forwardedFor);
+        }
+
+        if (forwardedProto is not null)
+        {
+            request.Headers.Add("X-Forwarded-Proto", forwardedProto);
+        }
+
+        var response = await client.SendAsync(request);
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Resolución de la dirección del cliente
+    // ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConDosSaltosResuelveLaDireccionDelCliente()
+    {
+        // Arrange: es la topología real, Cloudflare y el edge de Render.
+        using var host = await CrearHost("2");
+
+        // Act: el cliente es el primero por la izquierda; a la derecha, los proxies.
+        var resultado = await Pedir(host, "203.0.113.7, 198.51.100.1");
+
+        // Assert
+        _ = resultado.Should().StartWith("203.0.113.7");
+    }
+
+    [Fact]
+    public async Task ConElLimitePorDefectoDeUnoSeQuedaEnLaDireccionDelProxy()
+    {
+        // Arrange: es el defecto que motiva este issue. El valor por defecto del
+        // framework es 1, insuficiente para una cadena de dos proxies.
+        using var host = await CrearHost("1");
+
+        // Act
+        var resultado = await Pedir(host, "203.0.113.7, 198.51.100.1");
+
+        // Assert: se queda en el proxy, no llega al cliente
+        _ = resultado.Should().StartWith("198.51.100.1");
+    }
+
+    [Fact]
+    public async Task SinConfigurarUsaDosSaltosPorDefecto()
+    {
+        // Arrange: el default de esta aplicación es 2, no el 1 del framework.
+        using var host = await CrearHost(null);
+
+        // Act
+        var resultado = await Pedir(host, "203.0.113.7, 198.51.100.1");
+
+        // Assert
+        _ = resultado.Should().StartWith("203.0.113.7");
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Defensa contra falsificación
+    // ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DescartaLaDireccionQueElClienteAntepone()
+    {
+        // Arrange: el atacante antepone una dirección falsa; los proxies añaden las
+        // suyas a la derecha. Esta es la prueba que da sentido a ForwardLimit.
+        using var host = await CrearHost("2");
+
+        // Act: "9.9.9.9" la puso el cliente; las dos siguientes, los proxies reales.
+        var resultado = await Pedir(host, "9.9.9.9, 203.0.113.7, 198.51.100.1");
+
+        // Assert: la falsificada se descarta y se resuelve la que puso el primer proxy
+        _ = resultado.Should().StartWith("203.0.113.7");
+        _ = resultado.Should().NotContain("9.9.9.9");
+    }
+
+    [Fact]
+    public async Task UnaCadenaMuyLargaNoPermiteSuplantarLaDireccion()
+    {
+        // Arrange: por muchas entradas que anteponga el cliente, solo se consideran
+        // las dos de la derecha.
+        using var host = await CrearHost("2");
+
+        // Act
+        var resultado = await Pedir(
+            host,
+            "1.1.1.1, 2.2.2.2, 3.3.3.3, 4.4.4.4, 203.0.113.7, 198.51.100.1"
+        );
+
+        // Assert
+        _ = resultado.Should().StartWith("203.0.113.7");
+    }
+
+    [Fact]
+    public async Task UnLimiteInvalidoNoDegradaAConfiarEnTodo()
+    {
+        // Arrange: un valor mal escrito en la configuración no debe convertirse en
+        // "acepta cualquier cadena", que sería el fallo peligroso.
+        using var host = await CrearHost("no-es-un-numero");
+
+        // Act
+        var resultado = await Pedir(host, "9.9.9.9, 203.0.113.7, 198.51.100.1");
+
+        // Assert: cae al valor por defecto, que sigue descartando la falsificada
+        _ = resultado.Should().StartWith("203.0.113.7");
+    }
+
+    [Fact]
+    public async Task UnLimiteCeroONegativoCaeAlValorPorDefecto()
+    {
+        // Arrange
+        using var host = await CrearHost("0");
+
+        // Act
+        var resultado = await Pedir(host, "9.9.9.9, 203.0.113.7, 198.51.100.1");
+
+        // Assert
+        _ = resultado.Should().StartWith("203.0.113.7");
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Protocolo original
+    // ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RespetaElProtocoloOriginalDelCliente()
+    {
+        // Arrange: el proxy termina TLS y habla http con la aplicación. Sin esto, la
+        // aplicación creería que la petición llegó sin cifrar.
+        using var host = await CrearHost("2");
+
+        // Act
+        var resultado = await Pedir(host, "203.0.113.7, 198.51.100.1", "https");
+
+        // Assert
+        _ = resultado.Should().EndWith("|https");
+    }
+
+    [Fact]
+    public async Task SinCabecerasNoAlteraLaPeticion()
+    {
+        // Arrange: una petición directa, sin proxy delante, debe pasar intacta.
+        using var host = await CrearHost("2");
+
+        // Act
+        var resultado = await Pedir(host, forwardedFor: null);
+
+        // Assert
+        _ = resultado.Should().EndWith("|http");
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Redes conocidas
+    // ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConRedesConocidasIgnoraLaCabeceraDeUnPeerDesconocido()
+    {
+        // Arrange: al declarar redes, el middleware solo procesa la cabecera si el peer
+        // inmediato pertenece a ellas. El servidor de pruebas no está en 10.0.0.0/8.
+        using var host = await CrearHost("2", "10.0.0.0/8");
+
+        // Act
+        var resultado = await Pedir(host, "203.0.113.7, 198.51.100.1");
+
+        // Assert: no se aplica la cabecera, así que no aparece la dirección del cliente
+        _ = resultado.Should().NotStartWith("203.0.113.7");
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+# Stack local con un proxy inverso delante de la API.
+#
+# En produccion el proxy lo pone Render, que no es configurable desde este repo. Este
+# compose existe para poder verificar de verdad el comportamiento de las cabeceras
+# reenviadas contra un proxy real, y como base si algun dia se autoaloja.
+#
+#   docker compose up --build
+#   curl -s http://localhost:8080/health/ready
+#
+services:
+  api:
+    build: .
+    environment:
+      # La API no se publica al exterior: solo el proxy habla con ella. Es la misma
+      # topologia que en produccion, donde el contenedor no es accesible directamente.
+      ASPNETCORE_URLS: http://+:10000
+      # Un unico salto en local (solo NGINX), frente a los dos de produccion
+      # (Cloudflare y el edge de Render).
+      FORWARDED_LIMIT: "1"
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT:-5432}
+      DB_NAME: ${DB_NAME}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      JWT_KEY: ${JWT_KEY}
+      JWT_ISSUER: ${JWT_ISSUER}
+      JWT_AUDIENCE: ${JWT_AUDIENCE}
+      JWT_EXPIRES_MINUTES: ${JWT_EXPIRES_MINUTES:-60}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:3000}
+      SMTP_HOST: ${SMTP_HOST}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USER: ${SMTP_USER}
+      SMTP_PASSWORD: ${SMTP_PASSWORD}
+      SMTP_FROM: ${SMTP_FROM}
+      BACKUP_DIR: /var/backups/gsp
+      # Deja ver en el log la cadena recibida y la direccion resuelta.
+      Logging__LogLevel__SistemaServicios.API.Middleware: Debug
+    volumes:
+      # Sin este montaje los respaldos mueren con el contenedor.
+      - ./backups:/var/backups/gsp
+
+  proxy:
+    image: nginx:1.27-alpine
+    depends_on:
+      api:
+        condition: service_healthy
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,28 @@
+server {
+    listen 80;
+    server_name _;
+
+    # Acorde al tope de subida de avatares que valida UserService (2 MB).
+    client_max_body_size 4m;
+
+    location / {
+        proxy_pass http://api:10000;
+
+        proxy_http_version 1.1;
+
+        # Sin estas cabeceras la API solo veria la direccion del propio proxy.
+        # $proxy_add_x_forwarded_for anexa el peer a la cadena existente en lugar de
+        # reemplazarla: por eso el cliente puede anteponer entradas, y por eso la
+        # aplicacion se defiende con ForwardLimit y no confiando en la cadena entera.
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header Host $host;
+
+        # Margen suficiente para un respaldo que tarde; la generacion ya es asincrona,
+        # pero la descarga del .sql sigue siendo sincrona.
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+    }
+}


### PR DESCRIPTION
## 📌 Resumen del Cambio

Delante de la API hay **dos proxies**: Cloudflare y el edge de Render. Sin configurar las cabeceras reenviadas, `RemoteIpAddress` es la del proxy y no la del usuario.

Hoy **nada registra la dirección**, así que no hay un defecto visible. El problema aparecería con el limitador de intentos del tramo de blindaje: contaría todos los intentos contra una sola dirección y **bloquearía a los usuarios legítimos** en cuanto alguien disparase el umbral.

---

## 🔍 Tipo de Cambio realizado

- [ ] 🐞 Corrección de error (`fix`)
- [x] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [x] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [x] 📚 Cambios en la documentación (`docs`)
- [x] Otro (especificar): `chore` — infraestructura

---

## 📂 Archivos Afectados

- `Extensions/ForwardedHeadersConfiguration.cs` — nuevo
- `Middleware/ForwardedHeadersDiagnostics.cs` — nuevo
- `Extensions/ApplicationServiceExtensions.cs`, `Program.cs`
- `docker-compose.yml`, `nginx/default.conf` — nuevos
- `README.md`, `.env.example`, `.gitattributes`
- `Tests/Integration/ForwardedHeadersTests.cs` — nuevo

---

## 🧪 ¿Cómo Probarlo?

```bash
docker compose up --build

curl -s http://localhost:8080/health/ready
curl -s -H "X-Forwarded-For: 9.9.9.9" http://localhost:8080/health/ready

docker compose logs api | grep "X-Forwarded-For recibido"
```

Debería verse que la dirección resuelta es la real y **no** la falsificada:

```
X-Forwarded-For recibido: 9.9.9.9, 172.18.0.1 | dirección resuelta: 172.18.0.1
```

```bash
cd backend && dotnet test
```

---

## ✅ Checklist

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [x] Se han actualizado o agregado pruebas
- [x] La documentación se actualizó si fue necesario
- [x] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Closes #128

### `ForwardLimit` es lo que protege, no las listas de proxies

`X-Forwarded-For` **se anexa, no se reemplaza**. Un cliente puede enviar una dirección inventada y los proxies añadirán las suyas *a la derecha*. El middleware toma las `N` entradas más a la derecha y descarta el resto:

```
Cliente envía:   X-Forwarded-For: 9.9.9.9
NGINX anexa:     X-Forwarded-For: 9.9.9.9, 203.0.113.7
Con LIMIT=1  ->  resuelve 203.0.113.7   (la falsificada se descarta)
```

**El valor por defecto del framework es 1**, que con esta topología devolvería la dirección de Cloudflare. Aquí el default es **2**, ajustable con `FORWARDED_LIMIT`.

Un valor **mayor** que los saltos reales haría confiar en entradas que controla quien llama. Uno **menor** deja la dirección del proxy. Por eso un valor inválido en configuración cae al default en lugar de degradar a "aceptar cualquier cadena", que sería el fallo peligroso — hay pruebas de ambos casos.

### Por qué se vacían las listas de proxies conocidos

En una plataforma gestionada **no se pueden enumerar** las direcciones del proxy, y con las listas por defecto (solo loopback) el middleware **no haría absolutamente nada**. Se vacían a propósito; quien pueda enumerarlas las aporta con `FORWARDED_NETWORKS`.

Es una concesión consciente: si el contenedor quedara accesible sin pasar por el proxy, se podría suplantar la dirección. En Render no lo está. `ForwardLimit` sigue siendo la defensa de fondo.

### La configuración se prueba, no se declara

`ForwardedHeadersConfiguration` vive aparte para que las pruebas ejerciten **exactamente la misma** configuración que aplica la API, y no una copia que pueda divergir sin que nadie lo note. Diez pruebas, entre ellas:

- una entrada anteponida por el cliente **se descarta**
- una cadena larga **no permite suplantar** la dirección
- un límite inválido o cero **no degrada** a confiar en todo
- con redes declaradas, la cabecera de un peer desconocido **se ignora**

### Un defecto que apareció al verificar

El middleware de diagnóstico registraba la cadena **ya consumida**: `UseForwardedHeaders` elimina las entradas que aplica. El log mostraba `9.9.9.9` en vez de `9.9.9.9, 172.18.0.1`, lo que habría llevado a calcular **menos saltos de los reales** — justo el dato que esa traza existe para medir. Se detectó al contrastar contra NGINX y se corrigió moviéndolo delante de `UseForwardedHeaders`.

### Verificación contra un proxy real

| Comprobación | Resultado |
|---|---|
| Petición normal a través de NGINX | dirección resuelta = cliente real |
| Con `X-Forwarded-For: 9.9.9.9` falsificado | `9.9.9.9, 172.18.0.1` → resuelve **172.18.0.1** |
| `depends_on: service_healthy` | espera a la sonda de #123 antes de arrancar el proxy |

### Sobre el `docker-compose`

En producción el proxy lo pone Render y **no es configurable desde este repositorio**. Este stack existe para verificar el comportamiento contra un proxy real y como base si algún día se autoaloja. La API queda **sin publicar al exterior**, igual que en producción.

El segundo commit fija LF en `*.conf` y `docker-compose.yml`: los consumen contenedores Linux, y es la misma clase de divergencia que dejó el contenedor sin arrancar en #133 por el shebang de `entrypoint.sh`.

### Lo que este PR no hace

No añade la dirección a `UserLog` ni implementa limitación por dirección. Este trabajo **evita que el rate limiting nazca roto**; no lo implementa.

### Verificación

Suite completa: **282 pruebas, 0 fallos** (eran 272). CSharpier y analizadores limpios con `TreatWarningsAsErrors`.
