### PR TITLE
ci: añade escaneo de seguridad con CodeQL y Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+version: 2
+
+# Tres ecosistemas activos en el repositorio. El de github-actions se olvida a
+# menudo y es de los mas utiles: mantiene al dia actions/checkout, setup-dotnet y
+# setup-node, hoy fijadas en @v4.
+#
+# Sobre el volumen: al activarlo, Dependabot abre una tanda inicial de golpe. El
+# frontend tiene dependencias muy recientes (Next 16, React 19, ESLint 10) y un
+# "overrides" de ajv que indica que ya hubo conflictos de resolucion. Sin limite ni
+# agrupacion, el ruido lleva a ignorar a Dependabot por completo, que es el peor
+# resultado posible: por eso hay open-pull-requests-limit y groups.
+
+updates:
+  # ── Backend (.NET) ───────────────────────────────────────────────
+  - package-ecosystem: nuget
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - backend
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      # Menores y parches en una sola PR: son las que casi nunca rompen y las que
+      # mas ruido generan si van por separado.
+      backend-menores:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+
+  # ── Frontend (npm) ───────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - frontend
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      frontend-menores:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+
+  # ── Workflows de GitHub Actions ──────────────────────────────────
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      acciones:
+        patterns:
+          - '*'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,83 @@
+name: Seguridad — CodeQL
+
+# El repositorio es publico, asi que CodeQL esta disponible sin GitHub Advanced
+# Security. La Parte H de la auditoria encontro ocho vulnerabilidades por revision
+# manual; varias son del tipo que CodeQL detecta. Una auditoria es una foto de un
+# instante: esto evita que la proxima regresion del mismo tipo llegue a main sin
+# que nadie la vea.
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+  schedule:
+    # Semanal: el escaneo programado detecta reglas nuevas sobre codigo que no ha
+    # cambiado, algo que los disparadores por push nunca cubren.
+    - cron: '17 4 * * 1'
+
+jobs:
+  analyze:
+    name: Analizar ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    # Permisos minimos: solo lo que necesita para publicar los resultados.
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: csharp
+            build-mode: manual
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      # ── 1. Checkout ──────────────────────────────────────────────
+      - name: Checkout del repositorio
+        uses: actions/checkout@v4
+
+      # ── 2. .NET 9 (solo para el analisis de C#) ───────────────────
+      - name: Configurar .NET 9
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      # ── 3. Inicializar CodeQL ────────────────────────────────────
+      - name: Inicializar CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-and-quality amplia el conjunto por defecto, que solo trae las
+          # consultas de seguridad de mayor confianza.
+          queries: security-and-quality
+
+      # ── 4. Compilar (C#) ─────────────────────────────────────────
+      # Se compila a mano en lugar de usar autobuild: la solucion tiene
+      # TreatWarningsAsErrors y herramientas locales, y un autobuild que falle
+      # dejaria el analisis de C# vacio sin que el workflow lo indique claramente.
+      - name: Restaurar paquetes NuGet
+        if: matrix.language == 'csharp'
+        run: dotnet restore backend/SistemaServicios.sln
+
+      - name: Compilar solucion
+        if: matrix.language == 'csharp'
+        run: dotnet build backend/SistemaServicios.sln --no-restore --configuration Release
+
+      # ── 5. Analizar ──────────────────────────────────────────────
+      - name: Ejecutar analisis de CodeQL
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## 📌 Resumen del Cambio

El repositorio no tenía **ningún control automático de seguridad**. Los workflows existentes verifican corrección (`backend-tests`) y estilo (`backend-lint`), pero nada revisaba patrones vulnerables ni dependencias con CVE conocido.

Se añaden CodeQL para C# y TypeScript, y Dependabot para NuGet, npm y GitHub Actions.

---

## 🔍 Tipo de Cambio realizado

- [ ] 🐞 Corrección de error (`fix`)
- [ ] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [ ] 🧪 Agregado o mejora de pruebas (`test`)
- [x] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

- `.github/workflows/codeql.yml` — nuevo
- `.github/dependabot.yml` — nuevo

Ningún archivo de código se modifica.

---

## 🧪 ¿Cómo Probarlo?

CodeQL se ejecuta **en esta misma PR**: el resultado del check es la verificación.

Tras el merge, los hallazgos aparecen en **Security → Code scanning**. Dependabot empieza a abrir PRs el lunes siguiente, o de inmediato desde **Insights → Dependency graph → Dependabot**.

---

## ✅ Checklist

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [ ] Se han actualizado o agregado pruebas
- [x] La documentación se actualizó si fue necesario
- [x] No hay errores en CI/CD

> No aplica añadir pruebas: el cambio son dos archivos de configuración de CI, y su verificación es la propia ejecución del workflow.

---

## 📎 Notas Adicionales

Closes #130

### Por qué importa aquí y no en abstracto

La **Parte H** de la auditoría documenta ocho vulnerabilidades encontradas por revisión manual, dos críticas. Varias son exactamente el tipo que CodeQL detecta: control de acceso ausente en un endpoint, asignación directa de campos sensibles desde un DTO. Una auditoría manual es una foto de un instante; el escaneo continuo evita que la próxima regresión del mismo tipo llegue a `dev` sin que nadie la vea.

### La incógnita del borrador queda resuelta

El issue advertía que, si el repositorio fuera privado sin GitHub Advanced Security, CodeQL podría no estar disponible y habría que recurrir a un escáner externo. **El repositorio es público**, así que CodeQL está disponible sin coste y sin cambiar el alcance.

### Compilación manual en lugar de `autobuild`

La solución tiene `TreatWarningsAsErrors` y herramientas locales. **Un `autobuild` que falle dejaría el análisis de C# vacío sin que el workflow lo indique con claridad** — el peor fallo posible en una herramienta de seguridad: parecer que funciona. Se compila explícitamente con los mismos pasos que `backend-tests.yml`.

TypeScript usa `build-mode: none`; no necesita compilación.

### El disparador semanal no es redundante

Detecta **reglas nuevas sobre código que no ha cambiado**, algo que ningún disparador por evento cubre.

### Dependabot: el ruido es el riesgo real

Al activarlo, Dependabot abre una tanda inicial de golpe. El frontend tiene dependencias muy recientes (Next 16, React 19, ESLint 10) y un `overrides` de `ajv` que indica que ya hubo conflictos de resolución.

**Sin límite ni agrupación, el ruido lleva a ignorar a Dependabot por completo, que es el peor resultado posible.** Por eso: menores y parches agrupados en una sola PR por ecosistema, y tope de 5 PRs abiertas.

Se incluye `github-actions`, que se olvida a menudo y es de los más útiles: mantiene al día `actions/checkout`, `setup-dotnet` y `setup-node`, hoy fijadas en `@v4`.

### Un detalle que habría fallado en silencio

`dependabot.yml` referencia la etiqueta `dependencies`, que **no existía** en el repositorio. Dependabot no crea las etiquetas que no encuentra: las habría descartado sin avisar. Se creó antes de abrir esta PR, junto con la verificación de que `backend`, `frontend` y `ci` sí existían.

### Lo que este PR no hace

**No corrige ninguna vulnerabilidad.** Los hallazgos de la Parte H tienen su propia cola P0/P1. Aquí solo se instala la red que evita que reaparezcan.

Queda pendiente, tras el merge, **triar los hallazgos de la primera ejecución**: cada uno corregido, descartado con justificación escrita, o convertido en issue. Un panel de seguridad con alertas sin atender no es mejor que no tener panel.

### Sobre `dependabot_security_updates`

La API del repositorio reporta esa opción como **deshabilitada**. Es un ajuste del repositorio, distinto de este archivo: `dependabot.yml` gobierna las actualizaciones de *versión*, mientras que las de *seguridad* se activan en **Settings → Code security**. Conviene encenderla, pero no se puede hacer desde este PR.
