### PR TITLE
fix(respaldos): serializa el estado del trabajo por nombre y no como número

### DIFF
--- a/backend/SistemaServicios.API/DTOs/Admin/BackupJobDto.cs
+++ b/backend/SistemaServicios.API/DTOs/Admin/BackupJobDto.cs
@@ -1,5 +1,20 @@
+using System.Text.Json.Serialization;
+
 namespace SistemaServicios.API.DTOs.Admin;
 
+/// <summary>
+/// Estados de un trabajo de respaldo.
+/// </summary>
+/// <remarks>
+/// El converter va sobre este enum y no en la configuración global de JSON a propósito.
+/// Aplicarlo globalmente cambiaría también <c>UserRole</c>, <c>RequestStatus</c> y los
+/// demás enums de la API, que hoy viajan como enteros y así los leen el login, el perfil
+/// y el panel de usuarios. Ese cambio rompería esos módulos de golpe.
+/// Sin el converter, el estado viajaba como número y el cliente, que compara contra
+/// nombres, no reconocía nunca el estado final: la pantalla sondeaba hasta agotar el tope
+/// mientras el respaldo ya estaba hecho.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter<BackupJobStatus>))]
 public enum BackupJobStatus
 {
     Pendiente = 0,

--- a/backend/SistemaServicios.Tests/Integration/AdminControllerTests.cs
+++ b/backend/SistemaServicios.Tests/Integration/AdminControllerTests.cs
@@ -457,6 +457,74 @@ public class AdminControllerTests : IClassFixture<AdminWebApplicationFactory>
         _ = response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
+    // ─────────────────────────────────────────────────────────────
+    // Contrato del cable: el estado viaja como nombre, no como número
+    // ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Comprueba el JSON <b>en crudo</b>, no el objeto deserializado.
+    /// Las demás pruebas leen la respuesta con ReadFromJsonAsync&lt;BackupJobDto&gt;, así que
+    /// un estado serializado como entero volvía a convertirse en el enum al leerlo y el
+    /// round-trip pasaba. El cliente no tiene ese lujo: compara contra cadenas, y con un
+    /// número no reconocía nunca el estado final. Esta prueba mira lo que el cliente ve.
+    /// </summary>
+    [Fact]
+    public async Task GetBackupJobSerializaElEstadoComoNombreYNoComoNumero()
+    {
+        // Arrange
+        _ = _backupMock
+            .Setup(s => s.GenerateBackupAsync())
+            .ReturnsAsync(
+                new BackupResponseDto
+                {
+                    FileName = "backup_20260226_120000.sql",
+                    CreatedAt = new DateTime(2026, 2, 26, 12, 0, 0, DateTimeKind.Utc),
+                    FileSizeBytes = 20480,
+                }
+            );
+
+        var token = GenerarToken(UserRole.Admin);
+        var creacion = await _client.SendAsync(BuildRequest("POST", "/api/admin/backup", token));
+        var job = await creacion.Content.ReadFromJsonAsync<BackupJobDto>();
+        _ = await EsperarEstadoFinal(job!.Id, token);
+
+        // Act: se lee el cuerpo tal cual llega, sin deserializar
+        var response = await _client.SendAsync(
+            BuildRequest("GET", $"/api/admin/backup/jobs/{job.Id}", token)
+        );
+        var crudo = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        _ = crudo.Should().Contain("\"status\":\"Completado\"");
+        _ = crudo.Should().NotContain("\"status\":2");
+    }
+
+    [Fact]
+    public async Task CreateBackupSerializaElEstadoComoNombreYNoComoNumero()
+    {
+        // El POST devuelve el trabajo recién encolado, y el cliente lo evalúa antes de
+        // empezar a sondear: si ese primer cuerpo trae un número, arranca ya desalineado.
+        _ = _backupMock
+            .Setup(s => s.GenerateBackupAsync())
+            .ReturnsAsync(
+                new BackupResponseDto
+                {
+                    FileName = "backup_20260226_120000.sql",
+                    CreatedAt = new DateTime(2026, 2, 26, 12, 0, 0, DateTimeKind.Utc),
+                    FileSizeBytes = 20480,
+                }
+            );
+
+        var token = GenerarToken(UserRole.Admin);
+
+        // Act
+        var response = await _client.SendAsync(BuildRequest("POST", "/api/admin/backup", token));
+        var crudo = await response.Content.ReadAsStringAsync();
+
+        // Assert: cualquiera de los estados no finales, pero siempre por su nombre
+        _ = crudo.Should().MatchRegex("\"status\":\"(Pendiente|EnProceso|Completado)\"");
+    }
+
     [Fact]
     public async Task DownloadBackupConPathTraversalNoAlcanzaArchivosFueraDelDirectorio()
     {

--- a/frontend/src/features/respaldos/domain/backup.model.ts
+++ b/frontend/src/features/respaldos/domain/backup.model.ts
@@ -20,6 +20,20 @@ export function esEstadoFinal(status: BackupJobStatus): boolean {
   return status === "Completado" || status === "Fallido";
 }
 
+const ESTADOS: readonly string[] = ["Pendiente", "EnProceso", "Completado", "Fallido"];
+
+/**
+ * Comprueba que el estado que llegó del servidor es uno de los que esta pantalla entiende.
+ *
+ * El backend serializaba el estado como número y aquí se comparaba contra nombres, así que
+ * `esEstadoFinal` devolvía siempre false y el sondeo agotaba el tope mientras el respaldo
+ * ya estaba hecho. Lo peor no fue el desajuste sino cómo falló: en silencio y durante minuto
+ * y medio. Un estado que no se reconoce tiene que notarse de inmediato.
+ */
+export function esEstadoConocido(status: unknown): status is BackupJobStatus {
+  return typeof status === "string" && ESTADOS.includes(status);
+}
+
 // Mismo patron que aplica el backend en BackupService.OpenBackup. Se replica aqui
 // para no llegar a pedir al servidor un nombre que ya sabemos que va a rechazar.
 // No es una medida de seguridad: la autoritativa es la del servidor.

--- a/frontend/src/features/respaldos/infrastructure/backup.repository.ts
+++ b/frontend/src/features/respaldos/infrastructure/backup.repository.ts
@@ -1,6 +1,30 @@
-import { backupService } from "@/services/backup.service";
+import { backupService, BackupJobData } from "@/services/backup.service";
 
-import { Backup, BackupJob, sortBackupsByDateDesc } from "../domain/backup.model";
+import {
+  Backup,
+  BackupJob,
+  esEstadoConocido,
+  sortBackupsByDateDesc,
+} from "../domain/backup.model";
+
+// Punto unico donde la respuesta cruda se convierte en algo que el dominio entiende.
+// Si el estado no se reconoce se corta aqui: dejarlo pasar lo convertiria en un sondeo
+// que nunca termina, que es justo el fallo que se vio en produccion.
+function aTrabajo(raw: BackupJobData): BackupJob {
+  if (!esEstadoConocido(raw.status)) {
+    throw new Error(
+      `El servidor devolvió un estado de respaldo no reconocido (${JSON.stringify(raw.status)}). ` +
+        "Puede que el respaldo se haya generado: recarga la lista para comprobarlo.",
+    );
+  }
+
+  return {
+    id: raw.id,
+    status: raw.status,
+    fileName: raw.fileName,
+    error: raw.error,
+  };
+}
 
 // Capa de infraestructura: traduce entre el servicio HTTP y el dominio.
 // La capa de aplicacion depende de este puerto, no de fetch.
@@ -19,11 +43,11 @@ export const httpBackupRepository: BackupRepository = {
 
   // Devuelve el trabajo encolado, no el archivo: el respaldo aun no existe.
   async generate() {
-    return backupService.generateBackup();
+    return aTrabajo(await backupService.generateBackup());
   },
 
   async getJob(jobId: string) {
-    return backupService.getBackupJob(jobId);
+    return aTrabajo(await backupService.getBackupJob(jobId));
   },
 
   async download(fileName: string) {

--- a/frontend/src/services/backup.service.ts
+++ b/frontend/src/services/backup.service.ts
@@ -14,12 +14,18 @@ export type BackupData = {
   fileSizeBytes: number;
 };
 
-/** Estados que devuelve el backend para un trabajo de respaldo. */
-export type BackupJobStatus = "Pendiente" | "EnProceso" | "Completado" | "Fallido";
-
+/**
+ * El trabajo tal como llega por la red, sin validar.
+ *
+ * `status` es `unknown` a propósito: antes se declaraba con el tipo de estados ya cerrado,
+ * lo que hacía creer al compilador que la respuesta estaba comprobada cuando nadie la había
+ * comprobado. El servidor mandaba un número y TypeScript no podía advertirlo, porque un tipo
+ * declarado sobre un `res.json()` es una afirmación, no una verificación. Quien lo estrecha
+ * es la capa de infraestructura.
+ */
 export type BackupJobData = {
   id: string;
-  status: BackupJobStatus;
+  status: unknown;
   fileName?: string;
   fileSizeBytes?: number;
   error?: string;

--- a/frontend/tests/respaldos.spec.ts
+++ b/frontend/tests/respaldos.spec.ts
@@ -169,6 +169,36 @@ test.describe('Panel de respaldos', () => {
     await expect(page.getByTestId('backups-error')).toContainText('No se pudo generar el respaldo');
   });
 
+  test('avisa de inmediato si el estado del trabajo no se reconoce', async ({ page }) => {
+    // Regresion del fallo visto en produccion. El backend serializaba el enum como
+    // numero (`"status":2`) y esta pantalla comparaba contra nombres, asi que no
+    // reconocia nunca el estado final: sondeaba noventa segundos mientras el respaldo
+    // ya estaba escrito en disco. El resto de mocks de este archivo mandaban cadenas
+    // porque yo asumi ese formato, de modo que ninguna prueba llego a ver el problema.
+    // Aqui se manda a proposito lo que mandaba el servidor de verdad.
+    await authenticate(page);
+    await mockList(page, []);
+
+    await page.route('**/api/Admin/backup', async route => {
+      await route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: JOB_ID, status: 0 }),
+      });
+    });
+
+    await mockEstadosDelTrabajo(page, [{ id: JOB_ID, status: 2 }]);
+
+    await page.goto(RESPALDOS_URL);
+    await page.getByTestId('generate-backup-button').click();
+
+    // Lo que se exige no es solo que avise, sino que avise pronto: el tope de sondeo
+    // son 90 s, y agotarlo en silencio fue justo lo que sufrio el administrador.
+    await expect(page.getByTestId('backups-error')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('backups-error')).toContainText('no reconocido');
+    await expect(page.getByTestId('generate-backup-button')).toBeEnabled();
+  });
+
   test('muestra el error cuando el encolado falla', async ({ page }) => {
     await authenticate(page);
     await mockList(page, []);


### PR DESCRIPTION
Closes #184

## El problema

Al pulsar «Generar respaldo» en el despliegue, el botón se quedaba en «Generando…» y la
tabla no se actualizaba nunca, aunque el respaldo **sí se había creado**: al recargar
aparecía. La pestaña de red mostraba peticiones continuas al endpoint de estado, todas
con 200.

`BackupJobStatus` es un enum de C# y no había ningún `JsonStringEnumConverter` en el
backend, así que System.Text.Json lo serializaba como entero. Esto es la respuesta real,
capturada por una de las pruebas nuevas antes del arreglo:

```json
{"id":"f2e21af6-…","status":2,"fileName":"backup_20260226_120000.sql","fileSizeBytes":20480}
```

Y el cliente compara contra nombres:

```ts
return status === "Completado" || status === "Fallido";
```

`2 === "Completado"` es siempre falso, así que el trabajo no se daba nunca por terminado:
sondeaba las 60 veces del tope a 1.5 s —**90 segundos**— y acababa mostrando «está
tardando más de lo esperado», que era falso.

Que el cable es numérico no lo deduje leyendo, lo confirmé contra código que ya funciona
en producción: `users-store.ts` hace `roleMap[u.role]` sobre un `role: number`, y
`profile.service.ts` y `auth-store.ts` tipan igual.

## Por qué ninguna prueba lo vio

Es la parte que más me interesaba corregir, porque las dos capas compartían el mismo
punto ciego:

- Las **de integración** leían la respuesta con `ReadFromJsonAsync<BackupJobDto>`, así que
  el `2` volvía a convertirse en el enum al deserializar y el round-trip pasaba sin mirar
  jamás el formato del cable.
- Los **mocks de Playwright** mandaban `status: 'Completado'` escrito a mano por mí en
  #162. El mock codificaba mi suposición, no la conducta del servidor.

Ninguna capa enfrentaba la salida real del servidor con el parseo real del cliente.

## El arreglo

Un converter sobre **este enum**, no en la configuración global de JSON:

```csharp
[JsonConverter(typeof(JsonStringEnumConverter<BackupJobStatus>))]
public enum BackupJobStatus
```

Aplicarlo globalmente cambiaría también `UserRole`, `RequestStatus` y los demás, que hoy
viajan como enteros y así los leen el login, el perfil y el panel de usuarios. Ese cambio
rompería esos módulos de golpe, y ninguno entra en el alcance de este arreglo.

## Que no vuelva a pasar

**Prueba de contrato en backend.** Lee el cuerpo **en crudo**, sin deserializar, y afirma
que aparece `"status":"Completado"` y no `"status":2`. La escribí antes del arreglo y la
vi fallar con el JSON literal de arriba; si el converter se cae, esta prueba lo dice.

**Prueba E2E de regresión.** Manda a propósito el formato numérico que mandaba el servidor
de verdad y exige que la pantalla avise en menos de 5 s. Se verificó contra el frontend
sin corregir: el botón se quedaba en «Generando…» deshabilitado, exactamente el síntoma
reportado.

**El frontend deja de fiarse del cable.** `BackupJobData.status` pasa a ser `unknown`,
porque declarar un tipo cerrado sobre un `res.json()` es una afirmación y no una
comprobación: el compilador creía que la respuesta estaba validada cuando nadie la había
validado. La capa de infraestructura lo estrecha en un único punto y corta si el estado no
se reconoce. El fallo no fue solo el desajuste, sino que se manifestó como minuto y medio
de silencio; ahora avisa de inmediato.

## Comprobación

- Backend: **284/284**, `csharpier check` limpio sobre 126 archivos.
- Frontend: **106/106** en Playwright (105 antes, +1 de regresión).

## Validación manual

En `/usuarios/respaldos` como administrador, pulsar «Generar respaldo». El botón debe
volver a su estado normal en cuanto termine el volcado —unos segundos— y la tabla debe
mostrar el archivo nuevo **sin recargar la página**.

Conviene hacerlo con la pestaña de red abierta: se verán unos pocos sondeos al endpoint de
estado y luego una petición al listado, en lugar de la ráfaga continua de antes.

## Nota

El frontend y el backend se despliegan por separado. Si el frontend llega primero, la
pantalla mostrará «estado de respaldo no reconocido» hasta que el backend se despliegue,
en vez del giro silencioso de 90 s. Es un mensaje honesto y desaparece solo al completarse
el despliegue del backend.
