### PR TITLE
feat(backend): logging estructurado con Serilog y trazas con OpenTelemetry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,13 @@ FILE_STORAGE=
 # desaparece junto con el contenedor.
 BACKUP_DIR=
 
+# Colector de OpenTelemetry al que exportar trazas y métricas (por ejemplo,
+# http://localhost:4317 para un colector OTLP local o un Jaeger).
+# Si se omite, la aplicación arranca igual y simplemente no exporta nada: la
+# instrumentación sigue activa, que es de donde sale el TraceId que aparece en
+# cada línea de log y permite reunir las de una misma petición.
+OTEL_EXPORTER_OTLP_ENDPOINT=
+
 SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
 SMTP_USER= usuario del correo

--- a/README.md
+++ b/README.md
@@ -143,6 +143,94 @@ curl -s -H "X-Forwarded-For: 9.9.9.9" http://localhost:8080/health/ready
 
 En producción el proxy lo pone Render; este compose sirve para verificar el comportamiento y como base si algún día se autoaloja.
 
+## 📋 Observabilidad — Logs y Telemetría
+
+### Dos bitácoras que no son lo mismo
+
+El sistema escribe en dos sitios distintos y conviene no confundirlos, porque
+responden preguntas diferentes:
+
+|  | `UserLog` (tabla) | Telemetría (stdout) |
+|---|---|---|
+| Responde | *quién hizo qué* | *por qué el sistema respondió mal o lento* |
+| Vive en | PostgreSQL | stdout → recolector de la plataforma |
+| Se consulta | desde el panel de administración | durante un incidente |
+| Retención | permanente, es evidencia | la que decida el agregador |
+
+Si un usuario reclama que le borraron algo, se mira `UserLog`. Si la aplicación
+va lenta o devuelve 500, se miran los logs de operación. Este apartado va de los
+segundos; los primeros no se han tocado.
+
+### Formato
+
+Serilog escribe **JSON compacto a stdout**, nunca a archivo: el contenedor es
+efímero y un archivo se perdería en cada redespliegue. Docker y Render recogen
+stdout sin configurar nada.
+
+```bash
+docker logs -f <contenedor>                 # en local
+# En Render: pestaña "Logs" del servicio
+```
+
+Cada línea lleva `TraceId` y `SpanId`. **Esa es la propiedad que hace útil el
+log**: durante un incidente permite reunir todas las líneas de una misma
+petición en lugar de adivinar cuáles corresponden al usuario que se quejó.
+
+```bash
+# Todas las líneas de una petición concreta
+docker logs <contenedor> | grep '"TraceId":"06ded6db324384e443897587f45aec09"'
+```
+
+Un login fallido en producción deja **un solo evento**, elevado a `Warning` por
+ser 4xx:
+
+```json
+{"@t":"...","@mt":"HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms",
+ "@l":"Warning","StatusCode":401,"Elapsed":1361.32,"ClientIp":"::1",
+ "TraceId":"06ded6db...","SpanId":"5ed3357b...","Environment":"Production"}
+```
+
+Las sondas de `/health` **no generan ninguna línea**: el contenedor las consulta
+cada 30 s y, sin excluirlas, el log sería sobre todo ruido de sondas. Si una
+sonda falla se nota porque el contenedor se reinicia, no por una línea de log.
+
+### Secretos
+
+Un enricher redacta las propiedades cuyo nombre delata un secreto —contraseñas,
+tokens, `Authorization`, cadenas de conexión, `PGPASSWORD`—, incluso dentro de
+objetos volcados enteros con `{@Dto}`.
+
+**Su alcance tiene un límite que conviene conocer:** actúa sobre las propiedades
+estructuradas, no sobre texto ya interpolado en la plantilla del mensaje. Es
+decir, `_logger.LogInformation($"clave {clave}")` sí filtra el secreto. La regla
+sigue siendo **no meter secretos en la plantilla**; el enricher es la red que
+recoge el descuido habitual, que es volcar el DTO completo. Ambos límites están
+documentados con pruebas en `SecretRedactionEnricherTests`.
+
+### Niveles
+
+Se configuran en `appsettings.json` (producción) y `appsettings.Development.json`:
+`Information` en producción y `Debug` en desarrollo, con el SQL de EF Core en
+`Warning` en producción para no volcar cada consulta.
+
+### Trazas
+
+OpenTelemetry instrumenta ASP.NET Core, `HttpClient` y Npgsql. La exportación al
+colector es **opcional**:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+```
+
+Sin esa variable la aplicación **arranca igual y no exporta nada**, que es la
+situación actual: no hay colector desplegado. La instrumentación sigue activa
+aunque no se exporte, porque de ella sale el `TraceId` de los logs.
+
+No se usa el paquete de instrumentación de EF Core ni el exportador de
+Prometheus: ambos siguen en preestreno y este build trata las advertencias como
+errores. Las trazas de base de datos se obtienen del driver con `AddNpgsql()`,
+que sí es estable.
+
 ## 📊 Índices de Base de Datos — Notas de Diseño
 
 ### `Users.Status` (índice parcial)

--- a/README.md
+++ b/README.md
@@ -158,8 +158,26 @@ responden preguntas diferentes:
 | Retención | permanente, es evidencia | la que decida el agregador |
 
 Si un usuario reclama que le borraron algo, se mira `UserLog`. Si la aplicación
-va lenta o devuelve 500, se miran los logs de operación. Este apartado va de los
-segundos; los primeros no se han tocado.
+va lenta o devuelve 500, se miran los logs de operación.
+
+### El puente entre ambas: `UserLog.TraceId`
+
+Cada entrada de `UserLog` guarda el `TraceId` de la petición que la originó. Es
+lo que permite pasar de una fila del panel —*"Usuario ana@ejemplo.com
+eliminado"*— a **todo lo que ocurrió técnicamente en esa misma petición**:
+
+```bash
+docker logs <contenedor> | grep '"TraceId":"<el de la fila>"'
+```
+
+Sin ese campo las dos bitácoras quedan incomunicadas y, ante una reclamación,
+hay que adivinar qué líneas del log corresponden a la acción registrada.
+
+El valor se toma de la petición en curso, **nunca del cuerpo de la petición**:
+aceptarlo del cliente permitiría apuntar una entrada a la traza de otra y el
+enlace dejaría de ser fiable. Es anulable porque una tarea en segundo plano no
+tiene traza, y porque las filas anteriores a la columna no la tienen; un valor
+inventado sería peor que su ausencia.
 
 ### Formato
 

--- a/backend/SistemaServicios.API/DTOs/UserLogDto.cs
+++ b/backend/SistemaServicios.API/DTOs/UserLogDto.cs
@@ -16,5 +16,11 @@ public class UserLogDto
 
     public LogStatus Status { get; set; }
 
+    /// <summary>
+    /// Traza de la petición que originó la acción. Permite buscar en el log de operación
+    /// todo lo que ocurrió en esa misma petición.
+    /// </summary>
+    public string? TraceId { get; set; }
+
     public DateTime CreatedAt { get; set; }
 }

--- a/backend/SistemaServicios.API/Extensions/ApplicationServiceExtensions.cs
+++ b/backend/SistemaServicios.API/Extensions/ApplicationServiceExtensions.cs
@@ -73,6 +73,11 @@ public static class ApplicationServiceExtensions
 
         services.AddDbContext<AppDbContext>(options => options.UseNpgsql(connectionString));
 
+        // Trazas y métricas. La exportación solo se activa si hay colector configurado;
+        // la instrumentación se registra siempre porque de ella sale el TraceId que
+        // correlaciona las líneas de log de una misma petición.
+        _ = services.AddTelemetry(config);
+
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<IRatingRepository, RatingRepository>();
 

--- a/backend/SistemaServicios.API/Extensions/LoggingConfiguration.cs
+++ b/backend/SistemaServicios.API/Extensions/LoggingConfiguration.cs
@@ -1,0 +1,89 @@
+using Serilog;
+using Serilog.Events;
+using Serilog.Formatting.Compact;
+using SistemaServicios.API.Logging;
+
+namespace SistemaServicios.API.Extensions;
+
+/// <summary>
+/// Configuración de Serilog, extraída para que las pruebas ejerciten la misma que usa la
+/// aplicación en lugar de una copia que puede divergir sin que nadie se entere.
+/// </summary>
+public static class LoggingConfiguration
+{
+    /// <summary>Rutas que no generan un evento de petición.</summary>
+    /// <remarks>
+    /// Las sondas del contenedor (issue #123) consultan <c>/health/ready</c> cada 30 s. Sin
+    /// esta exclusión, el log de producción sería mayoritariamente ruido de sondas y el
+    /// coste de retención se lo llevaría algo que no informa de nada: si la sonda falla, se
+    /// nota porque el contenedor se reinicia, no porque haya una línea de log.
+    /// </remarks>
+    private static readonly string[] RutasSilenciadas = ["/health"];
+
+    public static void Configure(
+        LoggerConfiguration logger,
+        IConfiguration configuration,
+        IHostEnvironment environment
+    )
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        _ = logger
+            .ReadFrom.Configuration(configuration)
+            .Enrich.FromLogContext()
+            .Enrich.WithProperty("Application", "SistemaServicios.API")
+            .Enrich.WithProperty("Environment", environment.EnvironmentName)
+            .Enrich.With<ActivityCorrelationEnricher>();
+
+        // La redacción va la última a propósito: así ve también las propiedades que
+        // añaden los enrichers anteriores y las del LogContext.
+        _ = logger.Enrich.With<SecretRedactionEnricher>();
+
+        // JSON compacto a stdout y nunca a archivo. El contenedor es efímero: un sink de
+        // archivo perdería los logs en cada redespliegue y reintroduciría la dependencia
+        // del sistema de archivos local que el issue #125 quitó del almacenamiento.
+        // Render, Docker y cualquier agregador recogen stdout sin configurar nada.
+        _ = logger.WriteTo.Console(new CompactJsonFormatter());
+    }
+
+    /// <summary>Decide si una petición merece su propio evento de log.</summary>
+    public static bool DebeRegistrarPeticion(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return !Array.Exists(
+            RutasSilenciadas,
+            ruta => context.Request.Path.StartsWithSegments(ruta)
+        );
+    }
+
+    /// <summary>
+    /// Nivel del evento de una petición: eleva los fallos y silencia las sondas.
+    /// </summary>
+    /// <remarks>
+    /// Las sondas se descartan devolviendo <c>Verbose</c> y no con un filtro aparte, porque
+    /// así es como Serilog deja fuera un evento: el nivel mínimo configurado es Information
+    /// en producción y Debug en desarrollo, de modo que Verbose nunca llega a un sink. Un
+    /// filtro propio duplicaría el mecanismo y podría discrepar de la configuración.
+    /// </remarks>
+    public static LogEventLevel NivelDePeticion(HttpContext context, Exception? ex)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (ex is not null || context.Response.StatusCode >= 500)
+        {
+            return LogEventLevel.Error;
+        }
+
+        if (!DebeRegistrarPeticion(context))
+        {
+            return LogEventLevel.Verbose;
+        }
+
+        return context.Response.StatusCode >= 400
+            ? LogEventLevel.Warning
+            : LogEventLevel.Information;
+    }
+}

--- a/backend/SistemaServicios.API/Extensions/TelemetryConfiguration.cs
+++ b/backend/SistemaServicios.API/Extensions/TelemetryConfiguration.cs
@@ -1,0 +1,86 @@
+using Npgsql;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace SistemaServicios.API.Extensions;
+
+/// <summary>
+/// Registro de OpenTelemetry para trazas y métricas.
+/// </summary>
+public static class TelemetryConfiguration
+{
+    /// <summary>Endpoint del colector. Sin él la aplicación arranca igual y no exporta.</summary>
+    public const string VariableDeEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
+    private const string NombreDelServicio = "SistemaServicios.API";
+
+    /// <summary>
+    /// Indica si hay un colector configurado al que exportar.
+    /// </summary>
+    public static bool HayColectorConfigurado(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return !string.IsNullOrWhiteSpace(configuration[VariableDeEndpoint]);
+    }
+
+    /// <summary>
+    /// Añade la instrumentación y, solo si hay colector, la exportación OTLP.
+    /// </summary>
+    /// <remarks>
+    /// La instrumentación se registra <b>siempre</b>, haya colector o no, y esto es
+    /// deliberado: es lo que garantiza que exista una <c>Activity</c> por petición y, con
+    /// ella, el <c>TraceId</c> que el enricher de correlación escribe en cada línea de log.
+    /// Sin instrumentación no habría traza que leer y los logs volverían a ser líneas
+    /// sueltas imposibles de enlazar. La exportación, en cambio, sí es condicional: hoy no
+    /// hay ningún colector desplegado, y apuntar a un endpoint inexistente solo produciría
+    /// reintentos y ruido en el arranque.
+    /// </remarks>
+    public static IServiceCollection AddTelemetry(
+        this IServiceCollection services,
+        IConfiguration configuration
+    )
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var exportar = HayColectorConfigurado(configuration);
+
+        _ = services
+            .AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService(NombreDelServicio))
+            .WithTracing(tracing =>
+            {
+                // El filtro deja fuera las sondas del contenedor: generarían una traza
+                // cada 30 s sin aportar nada, mismo criterio que en el log de peticiones.
+                // Y AddNpgsql da trazas a nivel de driver, que cubren la pregunta de
+                // "dónde se fue el tiempo" sin recurrir al paquete de instrumentación de
+                // EF Core, que sigue en preestreno y no cabe en un build que trata las
+                // advertencias como errores.
+                _ = tracing
+                    .AddAspNetCoreInstrumentation(options =>
+                        options.Filter = context =>
+                            !context.Request.Path.StartsWithSegments("/health")
+                    )
+                    .AddHttpClientInstrumentation()
+                    .AddNpgsql();
+
+                if (exportar)
+                {
+                    _ = tracing.AddOtlpExporter();
+                }
+            })
+            .WithMetrics(metrics =>
+            {
+                _ = metrics.AddAspNetCoreInstrumentation().AddHttpClientInstrumentation();
+
+                if (exportar)
+                {
+                    _ = metrics.AddOtlpExporter();
+                }
+            });
+
+        return services;
+    }
+}

--- a/backend/SistemaServicios.API/Logging/ActivityCorrelationEnricher.cs
+++ b/backend/SistemaServicios.API/Logging/ActivityCorrelationEnricher.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace SistemaServicios.API.Logging;
+
+/// <summary>
+/// Añade a cada línea de log el identificador de la traza activa.
+/// </summary>
+/// <remarks>
+/// Es la propiedad que convierte un montón de líneas sueltas en la historia de una
+/// petición concreta: sin ella, ante un incidente hay que adivinar qué líneas pertenecen
+/// al usuario que se quejó. ASP.NET Core ya crea la <see cref="Activity"/> por petición,
+/// así que aquí solo se lee; no se genera ningún identificador propio, porque uno inventado
+/// no casaría con el que exporta OpenTelemetry y se perdería la correlación entre logs y
+/// trazas, que es justo lo que se busca.
+/// </remarks>
+public sealed class ActivityCorrelationEnricher : ILogEventEnricher
+{
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        ArgumentNullException.ThrowIfNull(logEvent);
+        ArgumentNullException.ThrowIfNull(propertyFactory);
+
+        var activity = Activity.Current;
+
+        // Fuera de una petición —tareas en segundo plano, arranque— no hay traza y no
+        // se inventa: una propiedad vacía haría creer que la correlación existe.
+        if (activity is null)
+        {
+            return;
+        }
+
+        logEvent.AddPropertyIfAbsent(
+            propertyFactory.CreateProperty("TraceId", activity.TraceId.ToString())
+        );
+        logEvent.AddPropertyIfAbsent(
+            propertyFactory.CreateProperty("SpanId", activity.SpanId.ToString())
+        );
+    }
+}

--- a/backend/SistemaServicios.API/Logging/SecretRedactionEnricher.cs
+++ b/backend/SistemaServicios.API/Logging/SecretRedactionEnricher.cs
@@ -1,0 +1,114 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace SistemaServicios.API.Logging;
+
+/// <summary>
+/// Sustituye por una marca el valor de las propiedades cuyo nombre delata un secreto.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Alcance real, para no dar una falsa sensación de seguridad: esto actúa sobre las
+/// <b>propiedades estructuradas</b> del evento, no sobre el texto ya interpolado en la
+/// plantilla del mensaje. Si alguien escribe <c>_logger.LogInformation($"clave {clave}")</c>
+/// con interpolación de C#, el secreto llega al sink como parte del texto y aquí no hay
+/// nada que redactar. La defensa de verdad es no meter secretos en la plantilla; esto es
+/// la red que recoge el descuido habitual, que es volcar el DTO entero.
+/// </para>
+/// <para>
+/// Se compara el <b>nombre</b> de la propiedad y nunca su valor: buscar patrones dentro de
+/// los valores daría falsos positivos constantes y, peor, obligaría a recorrer datos que
+/// puede que ni sean texto.
+/// </para>
+/// </remarks>
+public sealed class SecretRedactionEnricher : ILogEventEnricher
+{
+    /// <summary>Marca visible: un valor vacío no distinguiría "redactado" de "no venía".</summary>
+    public const string Marca = "***REDACTADO***";
+
+    // Fragmentos, no nombres exactos: el descuido tipico no es una propiedad llamada
+    // "Password" sino "UserPassword", "PasswordHash" o "SmtpPassword".
+    private static readonly string[] FragmentosSensibles =
+    [
+        "password",
+        "passwd",
+        "pwd",
+        "contrasena",
+        "contraseña",
+        "secret",
+        "token",
+        "authorization",
+        "apikey",
+        "api_key",
+        "connectionstring",
+        "pgpassword",
+        "jwt",
+        "credential",
+    ];
+
+    /// <summary>Indica si el nombre de una propiedad delata que su valor es un secreto.</summary>
+    public static bool EsNombreSensible(string nombre)
+    {
+        return !string.IsNullOrEmpty(nombre)
+            && Array.Exists(
+                FragmentosSensibles,
+                fragmento => nombre.Contains(fragmento, StringComparison.OrdinalIgnoreCase)
+            );
+    }
+
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        ArgumentNullException.ThrowIfNull(logEvent);
+
+        // Se toma una instantanea: AddOrUpdateProperty modifica la coleccion que se recorre.
+        foreach (var propiedad in logEvent.Properties.ToArray())
+        {
+            var redactado = Redactar(propiedad.Key, propiedad.Value);
+
+            if (!ReferenceEquals(redactado, propiedad.Value))
+            {
+                logEvent.AddOrUpdateProperty(new LogEventProperty(propiedad.Key, redactado));
+            }
+        }
+    }
+
+    private static LogEventPropertyValue Redactar(string nombre, LogEventPropertyValue valor)
+    {
+        return EsNombreSensible(nombre) ? new ScalarValue(Marca) : RedactarInterior(valor);
+    }
+
+    // Un DTO volcado con {@Dto} llega como StructureValue: si no se entrara en el, la
+    // contrasena viajaria intacta dentro de un objeto cuyo nombre no delata nada.
+    private static LogEventPropertyValue RedactarInterior(LogEventPropertyValue valor)
+    {
+        switch (valor)
+        {
+            case StructureValue estructura:
+            {
+                var propiedades = estructura
+                    .Properties.Select(p => new LogEventProperty(p.Name, Redactar(p.Name, p.Value)))
+                    .ToArray();
+                return new StructureValue(propiedades, estructura.TypeTag);
+            }
+
+            case DictionaryValue diccionario:
+            {
+                var elementos = diccionario.Elements.Select(par =>
+                    KeyValuePair.Create(
+                        par.Key,
+                        Redactar(par.Key.Value?.ToString() ?? string.Empty, par.Value)
+                    )
+                );
+                return new DictionaryValue(elementos);
+            }
+
+            case SequenceValue secuencia:
+            {
+                return new SequenceValue(secuencia.Elements.Select(RedactarInterior).ToArray());
+            }
+
+            default:
+                return valor;
+        }
+    }
+}

--- a/backend/SistemaServicios.API/Migrations/20260814161132_AddTraceIdToUserLog.Designer.cs
+++ b/backend/SistemaServicios.API/Migrations/20260814161132_AddTraceIdToUserLog.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SistemaServicios.API.Data;
@@ -11,9 +12,11 @@ using SistemaServicios.API.Data;
 namespace SistemaServicios.API.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260814161132_AddTraceIdToUserLog")]
+    partial class AddTraceIdToUserLog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/SistemaServicios.API/Migrations/20260814161132_AddTraceIdToUserLog.cs
+++ b/backend/SistemaServicios.API/Migrations/20260814161132_AddTraceIdToUserLog.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SistemaServicios.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTraceIdToUserLog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TraceId",
+                table: "UserLogs",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TraceId",
+                table: "UserLogs");
+        }
+    }
+}

--- a/backend/SistemaServicios.API/Models/UserLog.cs
+++ b/backend/SistemaServicios.API/Models/UserLog.cs
@@ -42,5 +42,21 @@ public class UserLog
 
     public LogStatus Status { get; set; } = LogStatus.Exitoso;
 
+    /// <summary>
+    /// Traza de la petición en la que ocurrió la acción, para enlazar esta entrada con
+    /// las líneas de log de operación que dejó esa misma petición.
+    /// </summary>
+    /// <remarks>
+    /// Es el puente entre las dos bitácoras: esta tabla responde <i>quién hizo qué</i> y
+    /// el log de stdout responde <i>qué pasó por dentro</i>. Sin este campo son dos
+    /// mundos incomunicados y, ante una reclamación, hay que adivinar qué líneas del log
+    /// corresponden a la acción registrada aquí.
+    /// Es anulable porque no toda escritura ocurre dentro de una petición —una tarea en
+    /// segundo plano no tiene traza— y porque las filas anteriores a esta columna no la
+    /// tienen. Un valor inventado sería peor que su ausencia.
+    /// </remarks>
+    [MaxLength(32)]
+    public string? TraceId { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/backend/SistemaServicios.API/Program.cs
+++ b/backend/SistemaServicios.API/Program.cs
@@ -1,8 +1,24 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Serilog;
+using Serilog.Formatting.Compact;
 using SistemaServicios.API.Extensions;
 using SistemaServicios.API.Middleware;
 
+// Logger mínimo previo a la construcción del host. AddApplicationServices lanza si falta
+// DB_HOST, JWT_KEY o las credenciales SMTP, y esos fallos ocurren antes de que exista el
+// logger definitivo: sin esto, un arranque fallido en producción no deja rastro y solo se
+// ve el contenedor reiniciándose sin explicación.
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console(new CompactJsonFormatter())
+    .CreateBootstrapLogger();
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog(
+    (context, _, logger) =>
+        LoggingConfiguration.Configure(logger, context.Configuration, context.HostingEnvironment)
+);
 
 // --- 1. CONFIGURACIÓN LIMPIA (Aquí llamamos a tu clase nueva) ---
 builder.Services.AddApplicationServices(builder.Configuration);
@@ -23,6 +39,32 @@ var app = builder.Build();
 // UseForwardedHeaders consuma las entradas que aplica.
 app.UseMiddleware<ForwardedHeadersDiagnostics>();
 app.UseForwardedHeaders();
+
+// Después de UseForwardedHeaders y no antes: registrado delante, la dirección que anotaría
+// sería la del proxy y no la del cliente, que es justo lo que resolvió el issue #128.
+app.UseSerilogRequestLogging(options =>
+{
+    options.GetLevel = (context, _, exception) =>
+        LoggingConfiguration.NivelDePeticion(context, exception);
+
+    options.EnrichDiagnosticContext = (diagnostic, context) =>
+    {
+        var clientIp = context.Connection.RemoteIpAddress?.ToString();
+        if (clientIp is not null)
+        {
+            diagnostic.Set("ClientIp", clientIp);
+        }
+
+        // Solo si hay sesión: en las rutas anónimas no existe el reclamo y anotar un
+        // UserId vacío haría creer que la petición venía de alguien identificado.
+        var userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (userId is not null)
+        {
+            diagnostic.Set("UserId", userId);
+        }
+    };
+});
+
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();

--- a/backend/SistemaServicios.API/Services/UserLogService.cs
+++ b/backend/SistemaServicios.API/Services/UserLogService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using SistemaServicios.API.DTOs;
 using SistemaServicios.API.Interfaces;
 using SistemaServicios.API.Models;
@@ -27,6 +28,8 @@ public class UserLogService : IUserLogService
 
     public async Task<UserLogDto> CreateLogAsync(CreateUserLogDto dto)
     {
+        ArgumentNullException.ThrowIfNull(dto);
+
         var log = new UserLog
         {
             Id = Guid.NewGuid(),
@@ -34,6 +37,12 @@ public class UserLogService : IUserLogService
             Action = dto.Action,
             Detail = dto.Detail,
             Status = dto.Status,
+
+            // Se toma de la petición en curso y nunca del DTO. Aceptarlo del cliente
+            // permitiría apuntar una entrada de la bitácora a la traza de otra petición,
+            // y el enlace entre ambas bitácoras dejaría de ser fiable justo cuando más
+            // falta hace. Fuera de una petición no hay traza y queda nulo.
+            TraceId = Activity.Current?.TraceId.ToString(),
             CreatedAt = DateTime.UtcNow,
         };
 
@@ -50,6 +59,7 @@ public class UserLogService : IUserLogService
             Action = l.Action,
             Detail = l.Detail,
             Status = l.Status,
+            TraceId = l.TraceId,
             CreatedAt = l.CreatedAt,
         };
 }

--- a/backend/SistemaServicios.API/SistemaServicios.API.csproj
+++ b/backend/SistemaServicios.API/SistemaServicios.API.csproj
@@ -7,6 +7,13 @@
 
   <!-- Analizadores de código (linting) -->
   <ItemGroup>
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/backend/SistemaServicios.API/appsettings.Development.json
+++ b/backend/SistemaServicios.API/appsettings.Development.json
@@ -1,8 +1,11 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft.AspNetCore": "Information",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Information"
+      }
     }
   },
   "AllowedHosts": "*",

--- a/backend/SistemaServicios.API/appsettings.json
+++ b/backend/SistemaServicios.API/appsettings.json
@@ -1,8 +1,12 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Override": {
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      }
     }
   },
   "AllowedHosts": "*",

--- a/backend/SistemaServicios.Tests/Integration/LoggingTests.cs
+++ b/backend/SistemaServicios.Tests/Integration/LoggingTests.cs
@@ -111,7 +111,7 @@ public class LoggingTests : IClassFixture<LoggingWebApplicationFactory>
     {
         // Act: da igual que las credenciales sean inválidas; lo que se comprueba es qué
         // deja escrito la petición a su paso, y una que falla registra más, no menos.
-        _ = await _client.PostAsJsonAsync(
+        using var respuestaLogin = await _client.PostAsJsonAsync(
             "/api/auth/login",
             new { Email = "ana@ejemplo.com", Password = Contrasena }
         );
@@ -130,7 +130,7 @@ public class LoggingTests : IClassFixture<LoggingWebApplicationFactory>
     [Fact]
     public async Task CadaPeticionSeRegistraConSuTraceId()
     {
-        _ = await _client.GetAsync(new Uri("/api/auth/login", UriKind.Relative));
+        using var respuesta = await _client.GetAsync(new Uri("/api/auth/login", UriKind.Relative));
 
         var conTraza = _factory.Eventos.Where(e => e.Properties.ContainsKey("TraceId")).ToList();
 
@@ -148,7 +148,7 @@ public class LoggingTests : IClassFixture<LoggingWebApplicationFactory>
         // son dos mundos incomunicados: ante una reclamación habría que adivinar qué
         // líneas del log corresponden a la acción registrada en la tabla.
         var token = GenerarTokenDeAdmin();
-        var peticion = new HttpRequestMessage(HttpMethod.Post, "/api/UserLogs")
+        using var peticion = new HttpRequestMessage(HttpMethod.Post, "/api/UserLogs")
         {
             Content = JsonContent.Create(
                 new
@@ -162,7 +162,7 @@ public class LoggingTests : IClassFixture<LoggingWebApplicationFactory>
         };
         peticion.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        var respuesta = await _client.SendAsync(peticion);
+        using var respuesta = await _client.SendAsync(peticion);
         _ = respuesta.StatusCode.Should().Be(HttpStatusCode.Created);
 
         var creado = await respuesta.Content.ReadFromJsonAsync<UserLogDto>();
@@ -188,8 +188,8 @@ public class LoggingTests : IClassFixture<LoggingWebApplicationFactory>
     {
         var antes = _factory.Eventos.Count;
 
-        _ = await _client.GetAsync(new Uri("/health/live", UriKind.Relative));
-        _ = await _client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+        using var live = await _client.GetAsync(new Uri("/health/live", UriKind.Relative));
+        using var ready = await _client.GetAsync(new Uri("/health/ready", UriKind.Relative));
 
         var nuevos = _factory.Eventos.Skip(antes).ToList();
         var salida = RenderizarComoStdout(nuevos);

--- a/backend/SistemaServicios.Tests/Integration/LoggingTests.cs
+++ b/backend/SistemaServicios.Tests/Integration/LoggingTests.cs
@@ -1,0 +1,124 @@
+using System.Globalization;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using Serilog.Events;
+using Serilog.Formatting.Compact;
+using SistemaServicios.API.Extensions;
+using SistemaServicios.Tests.Unit;
+using Xunit;
+
+namespace SistemaServicios.Tests.Integration;
+
+/// <summary>
+/// Factory que añade un sink en memoria a la <b>misma</b> configuración de Serilog que usa
+/// la aplicación, invocando <see cref="LoggingConfiguration.Configure"/>. Copiar aquí la
+/// configuración habría hecho que las pruebas comprobaran una tubería paralela que puede
+/// divergir de la real sin que nadie se entere.
+/// </summary>
+public class LoggingWebApplicationFactory : CustomWebApplicationFactory
+{
+    public List<LogEvent> Eventos { get; } = [];
+
+    // Se aplica sobre el IHostBuilder y no en ConfigureWebHost porque UseSerilog no existe
+    // sobre IWebHostBuilder. Al ejecutarse después del registro de Program.cs, este logger
+    // sustituye al de la aplicación conservando su misma configuración.
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        _ = builder.UseSerilog(
+            (context, logger) =>
+            {
+                LoggingConfiguration.Configure(
+                    logger,
+                    context.Configuration,
+                    context.HostingEnvironment
+                );
+                _ = logger.WriteTo.Sink(new SinkDeMemoria(Eventos));
+            }
+        );
+
+        return base.CreateHost(builder);
+    }
+}
+
+public class LoggingTests : IClassFixture<LoggingWebApplicationFactory>
+{
+    private const string Contrasena = "Sup3rSecreta!";
+
+    private readonly LoggingWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public LoggingTests(LoggingWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    /// <summary>Renderiza los eventos igual que el formateador que escribe a stdout.</summary>
+    private static string RenderizarComoStdout(IEnumerable<LogEvent> eventos)
+    {
+        var formateador = new CompactJsonFormatter();
+        using var escritor = new StringWriter(CultureInfo.InvariantCulture);
+
+        foreach (var evento in eventos)
+        {
+            formateador.Format(evento, escritor);
+        }
+
+        return escritor.ToString();
+    }
+
+    [Fact]
+    public async Task ElLogDeUnLoginRealNuncaContieneLaContrasena()
+    {
+        // Act: da igual que las credenciales sean inválidas; lo que se comprueba es qué
+        // deja escrito la petición a su paso, y una que falla registra más, no menos.
+        _ = await _client.PostAsJsonAsync(
+            "/api/auth/login",
+            new { Email = "ana@ejemplo.com", Password = Contrasena }
+        );
+
+        var salida = RenderizarComoStdout(_factory.Eventos);
+
+        // Guardia contra una prueba vacía: si el sink no capturó nada, la afirmación de
+        // abajo pasaría sola y no probaría absolutamente nada.
+        _ = _factory.Eventos.Should().NotBeEmpty("el sink debe haber recibido eventos");
+        _ = salida.Should().Contain("/api/auth/login", "debe haberse registrado la petición");
+
+        // Assert
+        _ = salida.Should().NotContain(Contrasena);
+    }
+
+    [Fact]
+    public async Task CadaPeticionSeRegistraConSuTraceId()
+    {
+        _ = await _client.GetAsync(new Uri("/api/auth/login", UriKind.Relative));
+
+        var conTraza = _factory.Eventos.Where(e => e.Properties.ContainsKey("TraceId")).ToList();
+
+        // Es la propiedad que permite reunir las líneas de una misma petición durante un
+        // incidente; sin ella el log estructurado pierde casi todo su valor.
+        _ = conTraza.Should().NotBeEmpty();
+        _ = conTraza[0].Properties["TraceId"].ToString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task LasSondasDeSaludNoEnsucianElLog()
+    {
+        var antes = _factory.Eventos.Count;
+
+        _ = await _client.GetAsync(new Uri("/health/live", UriKind.Relative));
+        _ = await _client.GetAsync(new Uri("/health/ready", UriKind.Relative));
+
+        var nuevos = _factory.Eventos.Skip(antes).ToList();
+        var salida = RenderizarComoStdout(nuevos);
+
+        // El contenedor sondea cada 30 s: sin esta exclusión el log de producción sería
+        // sobre todo ruido de sondas, y se pagaría retención por algo que no informa.
+        _ = salida.Should().NotContain("/health/live");
+        _ = salida.Should().NotContain("/health/ready");
+    }
+}

--- a/backend/SistemaServicios.Tests/Integration/LoggingTests.cs
+++ b/backend/SistemaServicios.Tests/Integration/LoggingTests.cs
@@ -1,11 +1,17 @@
 using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Events;
 using Serilog.Formatting.Compact;
+using SistemaServicios.API.DTOs;
 using SistemaServicios.API.Extensions;
+using SistemaServicios.API.Models;
+using SistemaServicios.API.Services;
 using SistemaServicios.Tests.Unit;
 using Xunit;
 
@@ -57,6 +63,35 @@ public class LoggingTests : IClassFixture<LoggingWebApplicationFactory>
         _client = factory.CreateClient();
     }
 
+    /// <summary>Token de administrador firmado con la clave del entorno de pruebas.</summary>
+    private static string GenerarTokenDeAdmin()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["JwtSettings:Key"] = "ClaveSecretaParaIntegracionTests_32Ch!",
+                    ["JwtSettings:Issuer"] = "TestIssuer",
+                    ["JwtSettings:Audience"] = "TestAudience",
+                    ["JwtSettings:ExpiresInMinutes"] = "60",
+                }
+            )
+            .Build();
+
+        var usuario = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = "admin@test.com",
+            PasswordHash = "hash-no-relevante",
+            FirstName = "Admin",
+            LastName = "Test",
+            Role = UserRole.Admin,
+            Status = true,
+        };
+
+        return new TokenService(config).CreateToken(usuario);
+    }
+
     /// <summary>Renderiza los eventos igual que el formateador que escribe a stdout.</summary>
     private static string RenderizarComoStdout(IEnumerable<LogEvent> eventos)
     {
@@ -103,6 +138,49 @@ public class LoggingTests : IClassFixture<LoggingWebApplicationFactory>
         // incidente; sin ella el log estructurado pierde casi todo su valor.
         _ = conTraza.Should().NotBeEmpty();
         _ = conTraza[0].Properties["TraceId"].ToString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task LaBitacoraDeNegocioQuedaEnlazadaConElLogDeOperacion()
+    {
+        // Es el puente entre las dos bitácoras. UserLog responde "quién hizo qué" y vive
+        // en PostgreSQL; el log de stdout responde "qué pasó por dentro". Sin este enlace
+        // son dos mundos incomunicados: ante una reclamación habría que adivinar qué
+        // líneas del log corresponden a la acción registrada en la tabla.
+        var token = GenerarTokenDeAdmin();
+        var peticion = new HttpRequestMessage(HttpMethod.Post, "/api/UserLogs")
+        {
+            Content = JsonContent.Create(
+                new
+                {
+                    UserId = Guid.NewGuid(),
+                    Action = 6,
+                    Detail = "Usuario creado desde la prueba",
+                    Status = 0,
+                }
+            ),
+        };
+        peticion.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var respuesta = await _client.SendAsync(peticion);
+        _ = respuesta.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var creado = await respuesta.Content.ReadFromJsonAsync<UserLogDto>();
+
+        // La entrada guarda la traza de la petición que la originó...
+        _ = creado!.TraceId.Should().NotBeNullOrWhiteSpace();
+
+        // ...y esa traza aparece en el log de operación, que es lo que permite pasar de
+        // una fila del panel a todo lo que ocurrió técnicamente en esa misma petición.
+        var eventosDeLaTraza = _factory
+            .Eventos.Where(e =>
+                e.Properties.TryGetValue("TraceId", out var t)
+                && t.ToString().Contains(creado.TraceId!, StringComparison.Ordinal)
+            )
+            .ToList();
+
+        _ = eventosDeLaTraza.Should().NotBeEmpty();
+        _ = RenderizarComoStdout(eventosDeLaTraza).Should().Contain("/api/UserLogs");
     }
 
     [Fact]

--- a/backend/SistemaServicios.Tests/Unit/SecretRedactionEnricherTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/SecretRedactionEnricherTests.cs
@@ -1,0 +1,145 @@
+using System.Globalization;
+using FluentAssertions;
+using Serilog;
+using Serilog.Events;
+using SistemaServicios.API.Logging;
+using Xunit;
+
+namespace SistemaServicios.Tests.Unit;
+
+/// <summary>
+/// Pruebas del enricher de redacción. Se ejercita a través de un logger real y no
+/// invocando <c>Enrich</c> a mano, porque lo que importa es lo que acaba en el sink.
+/// </summary>
+public class SecretRedactionEnricherTests
+{
+    private static (ILogger Logger, List<LogEvent> Eventos) CrearLogger()
+    {
+        var eventos = new List<LogEvent>();
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .Enrich.With<SecretRedactionEnricher>()
+            .WriteTo.Sink(new SinkDeMemoria(eventos))
+            .CreateLogger();
+
+        return (logger, eventos);
+    }
+
+    [Theory]
+    [InlineData("Password")]
+    [InlineData("password")]
+    [InlineData("UserPassword")]
+    [InlineData("PasswordHash")]
+    [InlineData("SmtpPassword")]
+    [InlineData("PGPASSWORD")]
+    [InlineData("Token")]
+    [InlineData("AccessToken")]
+    [InlineData("Authorization")]
+    [InlineData("ConnectionString")]
+    [InlineData("ApiKey")]
+    public void RedactaLasPropiedadesCuyoNombreDelataUnSecreto(string nombre)
+    {
+        var (logger, eventos) = CrearLogger();
+
+        logger.Information("Evento con {" + nombre + "}", "valor-super-secreto");
+
+        var propiedad = eventos.Single().Properties[nombre];
+        _ = propiedad.ToString().Should().NotContain("valor-super-secreto");
+        _ = propiedad.ToString().Should().Contain("REDACTADO");
+    }
+
+    [Theory]
+    [InlineData("Email")]
+    [InlineData("UserId")]
+    [InlineData("RequestPath")]
+    [InlineData("StatusCode")]
+    public void NoTocaLasPropiedadesInocuas(string nombre)
+    {
+        // Redactar de más es tan malo como redactar de menos: un log sin el correo ni la
+        // ruta no sirve para diagnosticar nada.
+        var (logger, eventos) = CrearLogger();
+
+        logger.Information("Evento con {" + nombre + "}", "dato-visible");
+
+        _ = eventos.Single().Properties[nombre].ToString().Should().Contain("dato-visible");
+    }
+
+    [Fact]
+    public void RedactaDentroDeUnObjetoVolcadoEntero()
+    {
+        // El descuido habitual no es registrar la contraseña suelta, sino volcar el DTO
+        // completo con {@Dto}. Ahí el nombre de la propiedad externa no delata nada.
+        var (logger, eventos) = CrearLogger();
+
+        logger.Information(
+            "Intento de registro {@Datos}",
+            new
+            {
+                Email = "ana@ejemplo.com",
+                Password = "Sup3rSecreta!",
+                Nombre = "Ana",
+            }
+        );
+
+        var texto = eventos.Single().Properties["Datos"].ToString();
+        _ = texto.Should().NotContain("Sup3rSecreta!");
+        _ = texto.Should().Contain("REDACTADO");
+
+        // Y lo que no es secreto sigue estando: si se redactara el objeto entero, el log
+        // dejaría de servir justo cuando hace falta.
+        _ = texto.Should().Contain("ana@ejemplo.com");
+        _ = texto.Should().Contain("Ana");
+    }
+
+    [Fact]
+    public void RedactaDentroDeUnaColeccionDeObjetos()
+    {
+        var (logger, eventos) = CrearLogger();
+
+        logger.Information(
+            "Lote {@Usuarios}",
+            new[]
+            {
+                new { Email = "uno@ejemplo.com", Password = "clave-uno" },
+                new { Email = "dos@ejemplo.com", Password = "clave-dos" },
+            }
+        );
+
+        var texto = eventos.Single().Properties["Usuarios"].ToString();
+        _ = texto.Should().NotContain("clave-uno");
+        _ = texto.Should().NotContain("clave-dos");
+        _ = texto.Should().Contain("uno@ejemplo.com");
+    }
+
+    [Fact]
+    public void NoRedactaElTextoYaInterpoladoEnElMensaje()
+    {
+        // Documenta el límite real de esta defensa, para que nadie la crea infalible:
+        // con interpolación de C# el secreto viaja como parte del texto y aquí no queda
+        // ninguna propiedad que redactar. La regla sigue siendo no meter secretos en la
+        // plantilla del mensaje; el enricher es la red del descuido, no una garantía.
+        var (logger, eventos) = CrearLogger();
+        var clave = "Sup3rSecreta!";
+
+        logger.Information($"La clave era {clave}");
+
+        _ = eventos
+            .Single()
+            .RenderMessage(CultureInfo.InvariantCulture)
+            .Should()
+            .Contain("Sup3rSecreta!");
+    }
+
+    [Fact]
+    public void NoRedactaUnSecretoEscondidoTrasUnNombreInocuo()
+    {
+        // El otro límite: la decisión se toma por el nombre de la propiedad. Si alguien
+        // registra la contraseña bajo un nombre que no delata nada, pasa intacta. Queda
+        // como prueba para que el límite sea explícito y no una sorpresa en un incidente.
+        var (logger, eventos) = CrearLogger();
+
+        logger.Information("Dato {Valor}", "Sup3rSecreta!");
+
+        _ = eventos.Single().Properties["Valor"].ToString().Should().Contain("Sup3rSecreta!");
+    }
+}

--- a/backend/SistemaServicios.Tests/Unit/SinkDeMemoria.cs
+++ b/backend/SistemaServicios.Tests/Unit/SinkDeMemoria.cs
@@ -1,0 +1,32 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace SistemaServicios.Tests.Unit;
+
+/// <summary>
+/// Sink que guarda los eventos en memoria para poder afirmar sobre ellos.
+/// </summary>
+/// <remarks>
+/// Se escribe aquí en lugar de añadir un paquete de terceros: son diez líneas y evita una
+/// dependencia más en un proyecto que ya arrastra 69 alertas de Dependabot.
+/// </remarks>
+public sealed class SinkDeMemoria : ILogEventSink
+{
+    private readonly List<LogEvent> _eventos;
+    private readonly Lock _candado = new();
+
+    public SinkDeMemoria(List<LogEvent> eventos)
+    {
+        _eventos = eventos;
+    }
+
+    public void Emit(LogEvent logEvent)
+    {
+        // Serilog puede emitir desde varios hilos; sin el candado la lista se corrompe y
+        // el fallo aparecería como una prueba intermitente, que es lo peor de diagnosticar.
+        lock (_candado)
+        {
+            _eventos.Add(logEvent);
+        }
+    }
+}

--- a/backend/SistemaServicios.Tests/Unit/TelemetryConfigurationTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/TelemetryConfigurationTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
+using SistemaServicios.API.Extensions;
+using Xunit;
+
+namespace SistemaServicios.Tests.Unit;
+
+/// <summary>
+/// Comprueba que la telemetría no convierte al colector en un requisito de arranque.
+/// </summary>
+public class TelemetryConfigurationTests
+{
+    private static IConfiguration Configuracion(string? endpoint)
+    {
+        var valores = new Dictionary<string, string?>();
+
+        if (endpoint is not null)
+        {
+            valores[TelemetryConfiguration.VariableDeEndpoint] = endpoint;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(valores).Build();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SinEndpointNoSeConsideraQueHayaColector(string? endpoint)
+    {
+        _ = TelemetryConfiguration
+            .HayColectorConfigurado(Configuracion(endpoint))
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void ConEndpointSeConsideraQueHayColector()
+    {
+        _ = TelemetryConfiguration
+            .HayColectorConfigurado(Configuracion("http://localhost:4317"))
+            .Should()
+            .BeTrue();
+    }
+
+    [Fact]
+    public void LaAplicacionResuelveLaTelemetriaAunqueNoHayaColector()
+    {
+        // Es el caso de hoy en producción: no hay colector desplegado. Si la ausencia de
+        // la variable impidiera construir el proveedor, la aplicación no arrancaría por
+        // no poder exportar telemetría, que es exactamente lo que no debe ocurrir.
+        var services = new ServiceCollection();
+        _ = services.AddLogging();
+
+        _ = services.AddTelemetry(Configuracion(null));
+
+        using var provider = services.BuildServiceProvider();
+        _ = provider.GetService<TracerProvider>().Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
Refs #124

Implementa el tramo de observabilidad que se puede sostener hoy con paquetes
estables. El alcance se acordó al planificar: **Serilog completo y trazas
OpenTelemetry, sin Prometheus ni instrumentación de EF Core**, por las razones
que van más abajo.

## El problema

La única traza persistida era `UserLog`, que registra *quién hizo qué* y no *por
qué el sistema respondió mal*. Ante un 500 en producción no había manera de saber
cuál petición falló, dónde se fue el tiempo, ni desde cuándo pasaba. El
diagnóstico consistía en reproducir el fallo a mano.

## Qué entra

**Serilog a stdout en JSON compacto**, nunca a archivo: el contenedor es efímero
y un sink de archivo perdería los logs en cada redespliegue, además de reintroducir
la dependencia del sistema de archivos local que #125 quitó del almacenamiento.

**`TraceId` y `SpanId` en cada línea**, leídos de la `Activity` que ASP.NET Core ya
crea. No se genera un identificador propio a propósito: uno inventado no casaría
con el que exporta OpenTelemetry y se perdería la correlación entre logs y trazas.

**`UseSerilogRequestLogging` después de `UseForwardedHeaders`**, no antes. Colocado
delante, la dirección anotada sería la del proxy en lugar de la del cliente — justo
lo que resolvió #128.

**Las sondas de `/health` no generan ninguna línea.** El contenedor las consulta cada
30 s; sin excluirlas el log sería mayoritariamente ruido de sondas y se pagaría
retención por algo que no informa de nada. Se descartan devolviendo `Verbose`, que
es el mecanismo con el que Serilog deja fuera un evento; un filtro aparte duplicaría
la lógica y podría discrepar del nivel configurado.

**Enricher de redacción** para contraseñas, tokens, `Authorization`, cadenas de
conexión y `PGPASSWORD`, que entra dentro de los objetos volcados enteros con
`{@Dto}` — el descuido habitual.

**Trazas OpenTelemetry** de ASP.NET Core, `HttpClient` y Npgsql, con exportación OTLP
**condicionada** a `OTEL_EXPORTER_OTLP_ENDPOINT`: sin esa variable la aplicación
arranca igual y no exporta. La instrumentación sí se registra siempre, porque de
ella sale el `TraceId` de los logs.

## Lo que no entra, y por qué

Los dos criterios restantes de #124 —instrumentación de EF Core y `/metrics` de
Prometheus— **solo existen como `1.17.0-beta.1`**, y `backend/Directory.Build.props`
tiene `TreatWarningsAsErrors=true`. Además hoy no hay ningún colector ni scraper
desplegado, así que sería código que no puedo demostrar funcionando.

Las trazas de base de datos se cubren igualmente con `AddNpgsql()`, que sí tiene
versión estable, de modo que la pregunta de *dónde se fue el tiempo* queda
respondida sin meter preestreno en el build.

## Sobre la redacción, con precisión

El enricher **no** hace imposible filtrar un secreto, y prefiero que eso quede
escrito antes que dar una falsa sensación de seguridad. Actúa sobre propiedades
estructuradas; no cubre:

- texto ya interpolado en la plantilla (`$"clave {clave}"`),
- un secreto guardado bajo un nombre que no delata nada.

**Los dos límites tienen prueba propia**, para que sean explícitos y no una sorpresa
durante un incidente. La regla sigue siendo no meter secretos en la plantilla del
mensaje; el enricher es la red del descuido común.

## Comprobación

**311/311** pruebas (284 previas + 27 nuevas), build en Release con **0 advertencias**,
`csharpier check` limpio sobre 134 archivos.

Y verificado con la API **en ejecución real**, no solo con pruebas. En `Production`:

```json
{"@mt":"HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms",
 "@l":"Warning","StatusCode":401,"Elapsed":1361.32,"ClientIp":"::1",
 "TraceId":"06ded6db...","SpanId":"5ed3357b...","Environment":"Production"}
```

- La contraseña de un login: **0 apariciones** en toda la salida.
- `/health/live`: **0 líneas**.
- El arranque completo más dos peticiones: **6 líneas**.

Un detalle que casi me lleva a una conclusión falsa: el primer intento con
`ASPNETCORE_ENVIRONMENT=Production` seguía arrancando en `Development`, porque
`dotnet run` aplica `launchSettings.json`. Los números de arriba son con
`--no-launch-profile`, ya en Production de verdad.

La prueba de que las sondas no ensucian el log se verificó quitando la exclusión:
falla sin ella y pasa con ella.

## Validación manual

Con la API levantada, `docker logs` o la pestaña Logs de Render deben mostrar JSON
por línea. Para ver la correlación, hacer una petición cualquiera y filtrar por su
traza:

```bash
docker logs <contenedor> | grep '"TraceId":"<el-de-la-peticion>"'
```

Deben salir todas las líneas de esa petición y ninguna de otra.


---

## Añadido: el puente entre las dos bitácoras (`UserLog.TraceId`)

Incorporado a esta misma PR por no estar todavía mergeada.

`UserLog` responde *quién hizo qué* y el log de stdout responde *qué pasó por
dentro*. Estaban **incomunicados**: ante una reclamación había una fila que decía
*"Usuario ana@ejemplo.com eliminado"* y, por separado, un montón de líneas
operativas, sin manera de saber cuáles eran de esa acción.

Cada entrada de `UserLog` guarda ahora el `TraceId` de la petición que la originó:

```bash
docker logs <contenedor> | grep '"TraceId":"<el de la fila>"'
```

**El valor se toma de `Activity.Current`, nunca del DTO.** Aceptarlo del cliente
permitiría apuntar una entrada a la traza de otra petición y el enlace dejaría de
ser fiable; importa especialmente porque `POST /api/UserLogs` está abierto a
cualquier usuario autenticado.

La columna es **anulable a propósito**: una tarea en segundo plano no ocurre dentro
de una petición y no tiene traza, y las filas anteriores a la migración tampoco.
Un valor inventado sería peor que su ausencia. La migración solo añade una columna
anulable, así que no toca los datos existentes.

La prueba de integración no se conforma con que la columna se rellene: comprueba
que **ese mismo `TraceId` aparece en el log de operación de esa petición**, que es
lo único que demuestra que el enlace sirve para algo.

No se toca nada más de `UserLogService`, ni la tabla, ni las 11 llamadas que
escriben entradas desde `UserService` y `ServiceService`.

**312/312** pruebas, build en Release con 0 advertencias, `csharpier` limpio.

### Queda pendiente de tu decisión

`AddLogAsync` hace su propio `SaveChangesAsync`, **separado** del guardado de negocio.
En `UserService.CreateUserAsync` se guarda el usuario y luego, en otra transacción, la
bitácora. Si falla la segunda, el usuario queda creado **sin rastro** y además la
excepción sube al cliente, que ve un error en una operación que sí tuvo éxito.

Dos políticas posibles, y la elección no es técnica sino de negocio:

1. **Misma transacción** — si no se puede auditar, la acción no ocurre.
2. **Auditoría tolerante a fallos** — se captura, se registra el fallo a nivel
   operativo con su `TraceId`, y la operación de negocio se mantiene.

No he tocado nada de esto: va fuera del alcance de esta PR.