### PR TITLE
fix: elimina el ruido de avisos del despliegue y muestra la traza en la bitácora

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,11 @@ RUN chmod +x entrypoint.sh efbundle
 # ASPNETCORE_URLS sobreescribe el Kestrel configurado en appsettings.json.
 # Sin seccion Kestrel en appsettings.json, ASPNETCORE_URLS controla el binding.
 ENV ASPNETCORE_URLS=http://+:10000
+
+# La imagen base aspnet:9.0 trae ASPNETCORE_HTTP_PORTS=8080. ASPNETCORE_URLS gana de
+# todos modos, pero el host avisa en cada arranque de que esta ignorando ese valor.
+# Vaciarlo elimina el aviso sin cambiar el puerto: el binding lo sigue decidiendo URLS.
+ENV ASPNETCORE_HTTP_PORTS=
 EXPOSE 10000
 
 # Sonda de readiness: la instancia solo se considera sana si ademas alcanza la base.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,30 @@ Se configuran en `appsettings.json` (producción) y `appsettings.Development.jso
 `Information` en producción y `Debug` en desarrollo, con el SQL de EF Core en
 `Warning` en producción para no volcar cada consulta.
 
+### Avisos esperados al arrancar
+
+Dos avisos de **Data Protection** aparecen en cada arranque dentro del contenedor:
+
+```
+Storing keys in a directory '/root/.aspnet/DataProtection-Keys' that may not be
+persisted outside of the container.
+No XML encryptor configured. Key {…} may be persisted to storage in unencrypted form.
+```
+
+**Hoy son inofensivos, y conviene saber por qué.** Nada en esta aplicación usa Data
+Protection: no hay autenticación por cookie, ni antiforgery, ni sesiones, ni ningún
+`IDataProtector`. La autenticación es JWT firmado con `JWT_KEY`, que viene del entorno y
+no tiene relación con esas claves. ASP.NET Core inicializa el subsistema de todos modos,
+y de ahí los avisos. Que las claves se pierdan en cada redespliegue no cuesta nada,
+porque no protegen nada.
+
+**Cuándo dejan de ser inofensivos:** en el momento en que se añada autenticación por
+cookie, antiforgery o cualquier uso de `IDataProtector`. A partir de ahí, perder las
+claves al redesplegar invalidaría las sesiones o los tokens de todos los usuarios en cada
+despliegue. La solución entonces es persistirlas —por ejemplo en PostgreSQL, con
+`Microsoft.AspNetCore.DataProtection.EntityFrameworkCore`— y cifrarlas. No se hizo antes
+porque sería añadir una dependencia para proteger algo que no existe.
+
 ### Trazas
 
 OpenTelemetry instrumenta ASP.NET Core, `HttpClient` y Npgsql. La exportación al

--- a/backend/SistemaServicios.API/Extensions/LoggingConfiguration.cs
+++ b/backend/SistemaServicios.API/Extensions/LoggingConfiguration.cs
@@ -11,15 +11,6 @@ namespace SistemaServicios.API.Extensions;
 /// </summary>
 public static class LoggingConfiguration
 {
-    /// <summary>Rutas que no generan un evento de petición.</summary>
-    /// <remarks>
-    /// Las sondas del contenedor (issue #123) consultan <c>/health/ready</c> cada 30 s. Sin
-    /// esta exclusión, el log de producción sería mayoritariamente ruido de sondas y el
-    /// coste de retención se lo llevaría algo que no informa de nada: si la sonda falla, se
-    /// nota porque el contenedor se reinicia, no porque haya una línea de log.
-    /// </remarks>
-    private static readonly string[] RutasSilenciadas = ["/health"];
-
     public static void Configure(
         LoggerConfiguration logger,
         IConfiguration configuration,
@@ -53,10 +44,10 @@ public static class LoggingConfiguration
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        return !Array.Exists(
-            RutasSilenciadas,
-            ruta => context.Request.Path.StartsWithSegments(ruta)
-        );
+        // Las sondas del contenedor consultan /health cada 30 s y la plataforma sondea la
+        // raíz. Sin excluirlas, el log de producción sería mayoritariamente ruido: si una
+        // sonda falla se nota porque el contenedor se reinicia, no por una línea de log.
+        return !RutasDeSondeo.Es(context.Request.Path);
     }
 
     /// <summary>

--- a/backend/SistemaServicios.API/Extensions/RutasDeSondeo.cs
+++ b/backend/SistemaServicios.API/Extensions/RutasDeSondeo.cs
@@ -1,0 +1,41 @@
+namespace SistemaServicios.API.Extensions;
+
+/// <summary>
+/// Rutas que consultan la plataforma y el contenedor, no las personas.
+/// </summary>
+/// <remarks>
+/// La lista vive en un solo sitio porque la usan dos cosas distintas y separarlas
+/// llevaría a que una se actualizara sin la otra: el log de peticiones las excluye para no
+/// ahogarse en ruido de sondas, y la redirección a HTTPS las esquiva porque el sondeo
+/// interno de Render llega sin <c>X-Forwarded-Proto</c> y el middleware acabaría avisando
+/// de que no puede determinar el puerto.
+/// </remarks>
+public static class RutasDeSondeo
+{
+    private static readonly string[] Prefijos = ["/health"];
+
+    /// <remarks>
+    /// La raíz se compara de forma exacta y <b>nunca</b> por prefijo:
+    /// <c>StartsWithSegments("/")</c> casaría con todas las rutas del sistema. Aplicado al
+    /// log dejaría la aplicación muda, y aplicado a la redirección la desactivaría entera.
+    /// </remarks>
+    private static readonly string[] Exactas = ["/"];
+
+    /// <summary>Indica si la ruta la consulta la plataforma y no un usuario.</summary>
+    public static bool Es(PathString ruta)
+    {
+        if (
+            Array.Exists(
+                Exactas,
+                exacta => string.Equals(ruta.Value, exacta, StringComparison.OrdinalIgnoreCase)
+            )
+        )
+        {
+            return true;
+        }
+
+        // StartsWithSegments respeta los límites de segmento, así que "/healthcheck" no
+        // queda cubierto por el prefijo "/health".
+        return Array.Exists(Prefijos, prefijo => ruta.StartsWithSegments(prefijo));
+    }
+}

--- a/backend/SistemaServicios.API/Program.cs
+++ b/backend/SistemaServicios.API/Program.cs
@@ -85,11 +85,14 @@ app.Use(
     }
 );
 
-// Las sondas quedan fuera de la redirección a HTTPS. Hoy no redirige porque no hay
-// puerto HTTPS configurado, pero si alguien lo añadiera, la sonda del contenedor
-// recibiría un 307 y el contenedor pasaría a considerarse enfermo sin estarlo.
+// Las rutas de sondeo quedan fuera de la redirección a HTTPS, por dos motivos.
+// Si algún día se configura un puerto HTTPS, la sonda del contenedor recibiría un 307 y
+// el contenedor pasaría a considerarse enfermo sin estarlo. Y hoy, además, el sondeo
+// interno de Render llega sin X-Forwarded-Proto, así que el middleware intentaba redirigir,
+// no encontraba puerto HTTPS y dejaba un aviso por arranque. El tráfico real entra por
+// Cloudflare ya como https y nunca pasa por ahí.
 app.UseWhen(
-    context => !context.Request.Path.StartsWithSegments("/health"),
+    context => !RutasDeSondeo.Es(context.Request.Path),
     branch => branch.UseHttpsRedirection()
 );
 
@@ -118,6 +121,19 @@ app.MapHealthChecks(
         ResponseWriter = HealthCheckResponseWriter.WriteAsync,
     }
 );
+
+// Raíz del servicio. Render y Cloudflare la sondean, y sin mapearla cada sondeo
+// devolvía 404 y quedaba registrado como Warning, porque los 4xx se elevan: el mismo
+// ruido que se evitó en /health colándose por otra puerta.
+// Se mapean GET y HEAD porque el sondeo de la plataforma usa HEAD, y MapGet por sí solo
+// no lo atiende. La respuesta es deliberadamente escueta: el endpoint es anónimo, así
+// que no se exponen versión, entorno ni nada que ayude a perfilar el servicio.
+app.MapMethods(
+        "/",
+        ["GET", "HEAD"],
+        () => Results.Ok(new { service = "SistemaServicios.API", status = "ok" })
+    )
+    .AllowAnonymous();
 
 app.MapControllers();
 

--- a/backend/SistemaServicios.Tests/Integration/LoggingTests.cs
+++ b/backend/SistemaServicios.Tests/Integration/LoggingTests.cs
@@ -184,6 +184,26 @@ public class LoggingTests : IClassFixture<LoggingWebApplicationFactory>
     }
 
     [Fact]
+    public async Task LaRaizRespondeAGetYAHeadSinEnsuciarElLog()
+    {
+        // Render sondea la raíz con HEAD y Cloudflare con GET. Sin ruta mapeada devolvían
+        // 404, y como los 4xx se elevan a Warning, cada sondeo de la plataforma dejaba un
+        // aviso en producción.
+        var antes = _factory.Eventos.Count;
+
+        using var conGet = await _client.GetAsync(new Uri("/", UriKind.Relative));
+        using var peticionHead = new HttpRequestMessage(HttpMethod.Head, "/");
+        using var conHead = await _client.SendAsync(peticionHead);
+
+        // MapGet por sí solo no atiende HEAD: de ahí que se mapeen ambos verbos.
+        _ = conGet.StatusCode.Should().Be(HttpStatusCode.OK);
+        _ = conHead.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var salida = RenderizarComoStdout(_factory.Eventos.Skip(antes));
+        _ = salida.Should().NotContain("\"RequestPath\":\"/\"");
+    }
+
+    [Fact]
     public async Task LasSondasDeSaludNoEnsucianElLog()
     {
         var antes = _factory.Eventos.Count;

--- a/backend/SistemaServicios.Tests/Unit/RutasDeSondeoTests.cs
+++ b/backend/SistemaServicios.Tests/Unit/RutasDeSondeoTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using SistemaServicios.API.Extensions;
+using Xunit;
+
+namespace SistemaServicios.Tests.Unit;
+
+/// <summary>
+/// Comprueba qué rutas se consideran sondeo de plataforma.
+/// </summary>
+/// <remarks>
+/// Merece pruebas propias por un motivo concreto: silenciar la raíz con una comparación
+/// por prefijo en lugar de exacta dejaría el log <b>completamente mudo</b> y desactivaría
+/// la redirección entera, porque toda
+/// ruta empieza por "/". El fallo sería silencioso y solo se notaría durante un incidente,
+/// que es el peor momento posible para descubrir que no hay logs.
+/// </remarks>
+public class RutasDeSondeoTests
+{
+    private static DefaultHttpContext ContextoCon(string ruta)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = ruta;
+        return context;
+    }
+
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/health")]
+    [InlineData("/health/live")]
+    [InlineData("/health/ready")]
+    public void NoRegistraLasRutasDeSondeo(string ruta)
+    {
+        _ = LoggingConfiguration.DebeRegistrarPeticion(ContextoCon(ruta)).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("/api/auth/login")]
+    [InlineData("/api/Users")]
+    [InlineData("/api/Admin/backups")]
+    [InlineData("/swagger")]
+    // Comparte prefijo textual con "/health" pero no es un segmento suyo: debe registrarse.
+    [InlineData("/healthcheck")]
+    // Lo que de verdad importa: que silenciar la raíz no silencie todo lo que cuelga de ella.
+    [InlineData("/api")]
+    public void RegistraTodoLoDemas(string ruta)
+    {
+        _ = LoggingConfiguration.DebeRegistrarPeticion(ContextoCon(ruta)).Should().BeTrue();
+    }
+}

--- a/frontend/app/usuarios/logs/page.tsx
+++ b/frontend/app/usuarios/logs/page.tsx
@@ -47,6 +47,7 @@ type LogRow = {
   action: number;
   detail?: string;
   status: number;
+  traceId?: string;
   createdAt: string;
 };
 
@@ -242,6 +243,21 @@ export default function UserLogsPage() {
                           </HStack>
                           {log.detail && <Text color="muted">{log.detail}</Text>}
                           <Text fontSize="sm" color="muted">{log.userName}</Text>
+                          {/* Traza de la peticion que origino la accion. Es lo que permite
+                              pasar de esta fila a las lineas de log de operacion de esa
+                              misma peticion; sin mostrarla, el enlace existe en los datos
+                              pero no se puede usar desde aqui. */}
+                          {log.traceId && (
+                            <Text
+                              data-testid="log-trace-id"
+                              fontSize="xs"
+                              fontFamily="mono"
+                              color="muted"
+                              title="Traza de la peticion. Busca este valor en los logs del servidor."
+                            >
+                              traza {log.traceId}
+                            </Text>
+                          )}
                         </Stack>
                         <Text fontSize="sm" color="muted">
                           {new Date(log.createdAt).toLocaleString("es-HN")}

--- a/frontend/tests/logs.spec.ts
+++ b/frontend/tests/logs.spec.ts
@@ -12,6 +12,7 @@ const mockLogs = [
     action: 6,
     detail: "Usuario juan@test.com creado.",
     status: 0,
+    traceId: "06ded6db324384e443897587f45aec09",
     createdAt: "2026-03-11T10:00:00Z",
   },
   {
@@ -143,4 +144,20 @@ test('Link CRUD navega a /usuarios', async ({ page }) => {
 test('Link Usuarios registrados navega a /usuarios/registrados', async ({ page }) => {
   await page.getByRole('link', { name: 'Usuarios registrados' }).click();
   await expect(page).toHaveURL(/\/usuarios\/registrados/);
+});
+
+test('Logs muestra la traza para enlazar con el log de operacion', async ({ page }) => {
+  // El TraceId es el puente entre la bitacora de negocio y el log de operacion: sin
+  // mostrarlo, el dato existe en la respuesta de la API pero no se puede usar desde
+  // la pantalla, que era justo lo que faltaba.
+  const traza = page.getByTestId('log-trace-id');
+  await expect(traza).toHaveCount(1);
+  await expect(traza).toContainText('06ded6db324384e443897587f45aec09');
+});
+
+test('Logs no muestra traza en registros que no la tienen', async ({ page }) => {
+  // Las filas anteriores a la migracion no tienen traza, y una etiqueta vacia haria
+  // creer que si existe correlacion.
+  await expect(page.getByTestId('log-row')).toHaveCount(2);
+  await expect(page.getByTestId('log-trace-id')).toHaveCount(1);
 });


### PR DESCRIPTION
Refs #124

El despliegue dejaba **cinco avisos** en cada arranque. Cuatro se corrigen y el quinto
queda documentado por ser inofensivo hoy.

## Medido con el contenedor, no deducido

| | Antes | Después |
|---|---|---|
| Avisos en el arranque | **5** | **2** |
| Líneas de la raíz en el log | varias, en `Warning` | **0** |
| `GET /` y `HEAD /` | `404` | `200` |

Los dos que quedan son exactamente los de Data Protection, documentados abajo.

## El más grave era mío

La raíz no estaba mapeada, y como `NivelDePeticion` eleva los 4xx a `Warning`, **cada
sondeo de la plataforma dejaba un aviso**. En el log de producción se ven los dos
orígenes: Render por dentro (`"ClientIp":"::1"`) y Cloudflare por fuera
(`"ClientIp":"172.71.151.204"`). Era el ruido que se evitó excluyendo `/health`, colándose
por otra puerta.

Se mapean **GET y HEAD** porque el sondeo de la plataforma usa HEAD y `MapGet` por sí solo
no lo atiende. La respuesta es escueta a propósito —el endpoint es anónimo, no expone
versión ni entorno:

```json
{"service":"SistemaServicios.API","status":"ok"}
```

## Lo que apareció al escribir la prueba

La prueba seguía fallando: la raíz aún generaba una línea, esta vez del middleware de
redirección a HTTPS. Es el cuarto aviso de la lista, y la prueba reveló su causa.

**El sondeo interno de Render llega sin `X-Forwarded-Proto`**, así que el middleware
intentaba redirigir, no encontraba puerto HTTPS y avisaba. El tráfico real entra por
Cloudflare ya como `https` y nunca pasa por ahí. Se resuelve dejando las rutas de sondeo
fuera de la redirección, lo que además evita que una sonda reciba un `307` si algún día se
configura un puerto HTTPS.

## Un detalle que podía salir muy caro

La lista de rutas de sondeo la usan ahora dos cosas, así que se extrae a `RutasDeSondeo`
en vez de duplicarla. Dentro, la raíz se compara **de forma exacta y nunca por prefijo**:

`StartsWithSegments("/")` casaría con **todas** las rutas del sistema. Aplicado al log
dejaría la aplicación muda; aplicado a la redirección la desactivaría entera. Y sería un
fallo silencioso que solo se descubriría durante un incidente, en el peor momento posible.

Por eso lleva pruebas propias que lo fijan, incluidas `/healthcheck` y `/api` como rutas
que **sí** deben registrarse.

## Los dos que no se tocan, y por qué

Los avisos de Data Protection son inofensivos **hoy**, y lo verifiqué: nada en la
aplicación usa ese subsistema —no hay cookies, ni antiforgery, ni sesiones, ni
`IDataProtector`— y el JWT se firma con `JWT_KEY`, que no tiene relación con esas claves.
Perderlas al redesplegar no cuesta nada porque no protegen nada.

Añadir `DataProtection.EntityFrameworkCore` sería una dependencia para proteger algo que
no existe. Queda documentado en el README junto con **la condición que los vuelve
importantes**: el día que se añada autenticación por cookie o antiforgery, perder las
claves invalidaría las sesiones de todos en cada despliegue.

## Y se cierra el puente que #124 dejó a medias

El `TraceId` estaba en el DTO pero **la pantalla de bitácora no lo mostraba**, así que el
enlace entre las dos bitácoras existía en los datos y no se podía usar desde la interfaz.
Ahora cada fila muestra su traza, y **solo cuando existe**: las filas anteriores a la
migración no la tienen, y una etiqueta vacía haría creer que hay correlación donde no la hay.

## Comprobación

- Backend: **323/323**, build en Release con **0 advertencias**, `csharpier` limpio.
- Frontend: **15/15** en `logs.spec.ts`, `tsc --noEmit` limpio.
- Contenedor reconstruido y arrancado en `Production` para contar los avisos reales.

Nota: `eslint` reporta 2 errores preexistentes en `logs/page.tsx` (`set-state-in-effect`,
línea 121). Lo verifiqué revirtiendo mis cambios: aparecen igual sin ellos. Pertenecen a
#171 y no los toco aquí.